### PR TITLE
Section filtering

### DIFF
--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		F61A6B061F66AFD4007826CA /* DetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A6B041F66AFD4007826CA /* DetailsViewController.swift */; };
 		F61A6B091F698877007826CA /* CIOGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A6B081F698877007826CA /* CIOGroup.swift */; };
 		F61A6B0B1F698D03007826CA /* CIOAutocompleteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A6B0A1F698D03007826CA /* CIOAutocompleteResult.swift */; };
+		F62510C520529DD40040E3DF /* Collection+MapKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62510C420529DD40040E3DF /* Collection+MapKeys.swift */; };
 		F631A5D41F5861ED00A49BD1 /* SearchErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F631A5D31F5861ED00A49BD1 /* SearchErrorView.swift */; };
 		F631A5D61F5861F600A49BD1 /* SearchErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = F631A5D51F5861F600A49BD1 /* SearchErrorView.xib */; };
 		F631A5D81F58629B00A49BD1 /* constructor-io-error-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = F631A5D71F58628900A49BD1 /* constructor-io-error-icon.png */; };
@@ -164,6 +165,7 @@
 		F61A6B041F66AFD4007826CA /* DetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailsViewController.swift; sourceTree = "<group>"; };
 		F61A6B081F698877007826CA /* CIOGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIOGroup.swift; sourceTree = "<group>"; };
 		F61A6B0A1F698D03007826CA /* CIOAutocompleteResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIOAutocompleteResult.swift; sourceTree = "<group>"; };
+		F62510C420529DD40040E3DF /* Collection+MapKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+MapKeys.swift"; sourceTree = "<group>"; };
 		F631A5D31F5861ED00A49BD1 /* SearchErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchErrorView.swift; sourceTree = "<group>"; };
 		F631A5D51F5861F600A49BD1 /* SearchErrorView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchErrorView.xib; sourceTree = "<group>"; };
 		F631A5D71F58628900A49BD1 /* constructor-io-error-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "constructor-io-error-icon.png"; sourceTree = "<group>"; };
@@ -459,6 +461,14 @@
 			children = (
 			);
 			name = Delegate;
+			sourceTree = "<group>";
+		};
+		F62510C320529DC70040E3DF /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				F62510C420529DD40040E3DF /* Collection+MapKeys.swift */,
+			);
+			path = Collection;
 			sourceTree = "<group>";
 		};
 		F631A5D21F5861A200A49BD1 /* Error */ = {
@@ -820,6 +830,7 @@
 		F68A73101F56E5EC00FA4D1B /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				F62510C320529DC70040E3DF /* Collection */,
 				F19E289B1F5F1DA20022C814 /* Date */,
 				F650154C1F587240008E50C0 /* Color */,
 				F65015461F586A35008E50C0 /* UIView */,
@@ -1065,11 +1076,11 @@
 					};
 					F688A43E1F56B4B600F169C1 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 0920;
 					};
 					F688A4471F56B4B600F169C1 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0920;
 					};
 				};
 			};
@@ -1234,6 +1245,7 @@
 				F60BEA1D1F571C5C008F0053 /* SearchResultCell.swift in Sources */,
 				F64F46C51F59A6890094C697 /* AutocompleteViewModelDelegate.swift in Sources */,
 				F63809061F5D6D9C00C3B322 /* AbstractResponseParser.swift in Sources */,
+				F62510C520529DD40040E3DF /* Collection+MapKeys.swift in Sources */,
 				F63809031F5D6D1400C3B322 /* DependencyContainer.swift in Sources */,
 				F699C34B1F57F22400FD681A /* NSError+Errors.swift in Sources */,
 			);
@@ -1523,7 +1535,8 @@
 				PRODUCT_NAME = ConstructorAutocomplete;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1547,7 +1560,8 @@
 				PRODUCT_MODULE_NAME = ConstructorAutocomplete;
 				PRODUCT_NAME = ConstructorAutocomplete;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1562,7 +1576,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xd.SearchFWTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1577,7 +1592,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xd.SearchFWTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		F65015481F586A42008E50C0 /* UIView+FadeInOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65015471F586A42008E50C0 /* UIView+FadeInOut.swift */; };
 		F650154B1F587213008E50C0 /* CIOStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F650154A1F587213008E50C0 /* CIOStyle.swift */; };
 		F650154E1F58724B008E50C0 /* UIColor+RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = F650154D1F58724B008E50C0 /* UIColor+RGB.swift */; };
+		F674157B204D489B004F313B /* MockResponseParserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F674157A204D489B004F313B /* MockResponseParserDelegate.swift */; };
 		F680EDBE1F57FBBD0002F4E1 /* constructor-io-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = F699C34D1F57F45B00FD681A /* constructor-io-logo.png */; };
 		F688A4491F56B4B600F169C1 /* ConstructorAutocomplete.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F688A43F1F56B4B600F169C1 /* ConstructorAutocomplete.framework */; };
 		F688A4501F56B4B600F169C1 /* ConstructorAutocomplete-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = F688A4421F56B4B600F169C1 /* ConstructorAutocomplete-Swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -208,6 +209,7 @@
 		F65015471F586A42008E50C0 /* UIView+FadeInOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+FadeInOut.swift"; sourceTree = "<group>"; };
 		F650154A1F587213008E50C0 /* CIOStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOStyle.swift; sourceTree = "<group>"; };
 		F650154D1F58724B008E50C0 /* UIColor+RGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+RGB.swift"; sourceTree = "<group>"; };
+		F674157A204D489B004F313B /* MockResponseParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockResponseParserDelegate.swift; sourceTree = "<group>"; };
 		F688A43F1F56B4B600F169C1 /* ConstructorAutocomplete.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ConstructorAutocomplete.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F688A4421F56B4B600F169C1 /* ConstructorAutocomplete-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ConstructorAutocomplete-Swift.h"; sourceTree = "<group>"; };
 		F688A4431F56B4B600F169C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 			isa = PBXGroup;
 			children = (
 				F64F46A51F595B980094C697 /* ResultParserTests.swift */,
+				F674157A204D489B004F313B /* MockResponseParserDelegate.swift */,
 			);
 			path = Result;
 			sourceTree = "<group>";
@@ -1256,6 +1259,7 @@
 				F174C1ED1F5F5AC1009E354B /* NSString+RangeOfCharactersTest.swift in Sources */,
 				F64F46C11F59850C0094C697 /* TestConstants.swift in Sources */,
 				F1C557411F5F67CA0040D6AD /* CIOHighlighterTests.swift in Sources */,
+				F674157B204D489B004F313B /* MockResponseParserDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AutocompleteClient.xcodeproj/xcshareddata/xcschemes/AutocompleteClient.xcscheme
+++ b/AutocompleteClient.xcodeproj/xcshareddata/xcschemes/AutocompleteClient.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0830"
-   version = "1.8">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AutocompleteClient/FW/API/Parser/CIOResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/CIOResponseParser.swift
@@ -44,8 +44,10 @@ struct CIOResponseParser: AbstractResponseParser {
 
         var results = [String: [CIOResult]]()
         
-        for section in sections {
-            results[section.key] = self.jsonToAutocompleteItems(jsonObjects: section.value)
+        for section in sections{
+            if self.delegate?.shouldParseResults(inSectionWithName: section.key) ?? true{
+                results[section.key] = self.jsonToAutocompleteItems(jsonObjects: section.value)
+            }
         }
 
         var metadata = json

--- a/AutocompleteClient/FW/API/Parser/ResponseParserDelegate.swift
+++ b/AutocompleteClient/FW/API/Parser/ResponseParserDelegate.swift
@@ -10,4 +10,5 @@ import Foundation
 
 public protocol ResponseParserDelegate: class{
     func shouldParseResult(result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool
+    func shouldParseResults(inSectionWithName name: String) -> Bool
 }

--- a/AutocompleteClient/FW/Logic/Highlighting/Attributes/BoldAttributesProvider.swift
+++ b/AutocompleteClient/FW/Logic/Highlighting/Attributes/BoldAttributesProvider.swift
@@ -20,10 +20,10 @@ class BoldAttributesProvider: CIOHighlightingAttributesProvider {
     }
 
     func defaultSubstringAttributes() -> [String: Any] {
-        return [NSFontAttributeName: self.fontNormal]
+        return [NSAttributedStringKey.font.rawValue: self.fontNormal]
     }
 
     func highlightedSubstringAttributes() -> [String: Any] {
-        return [NSFontAttributeName: self.fontBold]
+        return [NSAttributedStringKey.font.rawValue: self.fontBold]
     }
 }

--- a/AutocompleteClient/FW/Logic/Highlighting/CIOHighlighter.swift
+++ b/AutocompleteClient/FW/Logic/Highlighting/CIOHighlighter.swift
@@ -40,7 +40,7 @@ public class CIOHighlighter {
         while let (matches, result) = iterator.next() {
             guard matches else {
                 // Not-matched, add specified font for default
-                finalString.append(NSAttributedString(string: result, attributes: self.attributesProvider.defaultSubstringAttributes()))
+                finalString.append(NSAttributedString(string: result, attributes: self.attributesProvider.defaultSubstringAttributes().mapToAttributedStringKeys()))
                 continue
             }
             
@@ -49,9 +49,9 @@ public class CIOHighlighter {
             let (prefix, suffix) = getBestPrefixBetween(prefixers: searchTokens, prefixee: result)
             
             // Add specified font for highlighted
-            finalString.append(NSAttributedString(string: prefix, attributes: self.attributesProvider.highlightedSubstringAttributes()))
+            finalString.append(NSAttributedString(string: prefix, attributes: self.attributesProvider.highlightedSubstringAttributes().mapToAttributedStringKeys()))
             // Add specified font for non-highlighted
-            finalString.append(NSAttributedString(string: suffix, attributes: self.attributesProvider.defaultSubstringAttributes()))
+            finalString.append(NSAttributedString(string: suffix, attributes: self.attributesProvider.defaultSubstringAttributes().mapToAttributedStringKeys()))
         }
         return finalString
     }
@@ -60,15 +60,15 @@ public class CIOHighlighter {
     private func getBestPrefixBetween(prefixers: [String], prefixee: String) -> (String, String) {
         var bestMatch = 0
         for prefixer in prefixers {
-            if prefixer.characters.count > prefixee.characters.count {
+            if prefixer.count > prefixee.count {
                 continue
             }
-            guard prefixee.lowercased().hasPrefix(prefixer.lowercased()), prefixer.characters.count > bestMatch else { continue }
-            bestMatch = prefixer.characters.count
+            guard prefixee.lowercased().hasPrefix(prefixer.lowercased()), prefixer.count > bestMatch else { continue }
+            bestMatch = prefixer.count
         }
         let index = prefixee.index(prefixee.startIndex, offsetBy: bestMatch)
-        return (prefixee.substring(to: index), prefixee.substring(from: index))
-//        return (String(prefixee[..<index]), String(prefixee[index...]))
+        
+        return (String(prefixee[..<index]), String(prefixee[index...]))
     }
 }
 

--- a/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
+++ b/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
@@ -368,7 +368,7 @@ extension CIOAutocompleteViewController: UISearchResultsUpdating {
         let searchTerm = searchText.trim().lowercased()
         
         // check whether we have a valid search term
-        if searchTerm.characters.count == 0 {
+        if searchTerm.count == 0 {
             let query = CIOAutocompleteQuery(query: "", numResults: config?.numResults, numResultsForSection: config?.numResultsForSection)
             self.setResultsReceived(from: AutocompleteResult(query: query))
             return

--- a/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
+++ b/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
@@ -386,4 +386,7 @@ extension CIOAutocompleteViewController: ResponseParserDelegate {
         return self.delegate?.autocompleteController?(controller: self, shouldParseResult: result, inGroup: group) ?? true
     }
     
+    public func shouldParseResults(inSectionWithName name: String) -> Bool {
+        return self.delegate?.autocompleteController?(controller: self, shouldParseResultsInSection: name) ?? true
+    }
 }

--- a/AutocompleteClient/FW/UI/DefaultSearchItemCell.swift
+++ b/AutocompleteClient/FW/UI/DefaultSearchItemCell.swift
@@ -20,8 +20,13 @@ class DefaultSearchItemCell: UITableViewCell, CIOAutocompleteCell {
     func setup(result: CIOResult, searchTerm: String, highlighter: CIOHighlighter) {
         if let group = result.group{
             let groupString = NSMutableAttributedString()
-            groupString.append(NSAttributedString(string: "  in ", attributes: highlighter.attributesProvider.defaultSubstringAttributes()))
-            groupString.append(NSAttributedString(string: group.displayName, attributes: highlighter.attributesProvider.highlightedSubstringAttributes()))
+            
+            let defaultAttributes: [NSAttributedStringKey: Any] = highlighter.attributesProvider.defaultSubstringAttributes().mapToAttributedStringKeys()
+            
+            let highlightedAttributes: [NSAttributedStringKey: Any] = highlighter.attributesProvider.highlightedSubstringAttributes().mapToAttributedStringKeys()
+            
+            groupString.append(NSAttributedString(string: "  in ", attributes: defaultAttributes))
+            groupString.append(NSAttributedString(string: group.displayName, attributes: highlightedAttributes))
             self.labelText.attributedText =  groupString
         }else{
             self.labelText.attributedText = highlighter.highlight(searchTerm: searchTerm, itemTitle: result.autocompleteResult.value)

--- a/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
+++ b/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
@@ -42,6 +42,16 @@ public protocol CIOAutocompleteDelegate: class{
     optional func autocompleteController(controller: CIOAutocompleteViewController, didPerformSearch searchTerm: String)
 
     /**
+     Called during parsing to ask whether to parse results in a certain section. If the user returns false,
+     the whole section will be ignored.
+     
+     - parameter controller: A CIOAutocompleteViewController in which the search occurred.
+     - parameter sectionName: Section name
+     */
+    @objc
+    optional func autocompleteController(controller: CIOAutocompleteViewController, shouldParseResultsInSection sectionName: String) -> Bool
+   
+    /**
      Called during parsing to ask whether to parse a certain result. If the user returns false for an item
      with nil group (the original item), the search-in-group items won't get parsed.
      

--- a/AutocompleteClient/Utils/Collection/Collection+MapKeys.swift
+++ b/AutocompleteClient/Utils/Collection/Collection+MapKeys.swift
@@ -1,0 +1,29 @@
+//
+//  Collection+MapKeys.swift
+//  AutocompleteClient
+//
+//  Created by Nikola Markovic on 3/9/18.
+//  Copyright © 2018 xd. All rights reserved.
+//
+
+import Foundation
+
+extension Dictionary{
+    func mapKeys<T>(_ mapping: (_ key: Key) -> T) -> [T: Value]{
+        var newDictionary: [T: Value] = [:]
+        for (k,v) in self{
+            
+            newDictionary[mapping(k)] = v
+        }
+        
+        return newDictionary
+    }
+}
+
+extension Dictionary where Key == String, Value == Any{
+    
+    func mapToAttributedStringKeys() -> [NSAttributedStringKey: Any]{
+        let keyMapping: (String) -> NSAttributedStringKey = { key in return NSAttributedStringKey(rawValue: key) }
+        return self.mapKeys(keyMapping)
+    }
+}

--- a/AutocompleteClientTests/Logic/Highlighting/CIOHighlighterTests.swift
+++ b/AutocompleteClientTests/Logic/Highlighting/CIOHighlighterTests.swift
@@ -23,7 +23,7 @@ class CIOHighlighterTests: XCTestCase {
 
     func testHighlighter_NoMatches_NoHighlights() {
         let result = highlighter.highlight(searchTerm: "this is a test", itemTitle: "no matches in item!")
-        XCTAssertEqual(result, NSAttributedString(string: "no matches in item!", attributes: [NSFontAttributeName: provider.fontNormal]))
+        XCTAssertEqual(result, NSAttributedString(string: "no matches in item!", attributes: [NSAttributedStringKey.font: provider.fontNormal]))
     }
 
     func testHighlighter_AllMatch_AllHighlighted() {
@@ -53,12 +53,12 @@ class CIOHighlighterTests: XCTestCase {
         for string in strings {
             guard shouldHighlight else {
                 
-                highlightedString.append(NSAttributedString(string: string, attributes: [NSFontAttributeName: provider.fontNormal]))
+                highlightedString.append(NSAttributedString(string: string, attributes: [NSAttributedStringKey.font: provider.fontNormal]))
                 shouldHighlight = !shouldHighlight
                 continue
             }
 
-            highlightedString.append(NSAttributedString(string: string, attributes: [NSFontAttributeName: provider.fontBold]))
+            highlightedString.append(NSAttributedString(string: string, attributes: [NSAttributedStringKey.font: provider.fontBold]))
             shouldHighlight = !shouldHighlight
         }
 

--- a/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
+++ b/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  MockResponseParserDelegate.swift
+//  AutocompleteClientTests
+//
+//  Created by Nikola Markovic on 3/5/18.
+//  Copyright © 2018 xd. All rights reserved.
+//
+
+import Foundation
+@testable import ConstructorAutocomplete
+
+class MockResponseParserDelegate: NSObject, ResponseParserDelegate {
+
+    var shouldParseResultInGroup: (_ result: CIOAutocompleteResult, _ group: CIOGroup?) -> Bool = { _ in return true }
+    var shouldParseResultsInSection: (_ name: String) -> Bool = { _ in return true }
+    
+    func shouldParseResult(result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool{
+        return self.shouldParseResultInGroup(result, group)
+    }
+    
+    func shouldParseResults(inSectionWithName name: String) -> Bool{
+        return self.shouldParseResultsInSection(name)
+    }
+}

--- a/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
+++ b/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
@@ -11,7 +11,7 @@ import Foundation
 
 class MockResponseParserDelegate: NSObject, ResponseParserDelegate {
 
-    var shouldParseResultInGroup: (_ result: CIOAutocompleteResult, _ group: CIOGroup?) -> Bool = { _ in return true }
+    var shouldParseResultInGroup: (_ result: CIOAutocompleteResult, _ group: CIOGroup?) -> Bool = { _,_  in return true }
     var shouldParseResultsInSection: (_ name: String) -> Bool = { _ in return true }
     
     func shouldParseResult(result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool{

--- a/AutocompleteClientTests/Logic/Result/ResultParserTests.swift
+++ b/AutocompleteClientTests/Logic/Result/ResultParserTests.swift
@@ -78,4 +78,49 @@ class ResultParserTests: XCTestCase {
             XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
         }
     }
+    
+    func test_ParsingSpecificSectionInMultisectionJSON_ReturnsCorrectResults(){
+        let data = TestResource.load(name: TestResource.Response.multipleSectionsJSONFilename)
+        
+        // let's only parse items from the 'standard' section
+        let sectionName = "standard"
+        
+        // create mock delegate
+        let del = MockResponseParserDelegate()
+        del.shouldParseResultsInSection = { name in
+            return name.lowercased() == sectionName
+        }
+        self.responseParser.delegate = del
+        
+        do {
+            let response = try responseParser.parse(autocompleteResponseData: data)
+            
+            XCTAssertNotNil(response.sections[sectionName], "Results should include the section with the filtered name.")
+            XCTAssertEqual(response.sections.count, 1, "Results should only include the section with the filtered name.")
+        } catch {
+            XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
+        }
+    }
+    
+    func test_ParsingNonexistingSectionInMultisectionJSON_ReturnsNoResults(){
+        let data = TestResource.load(name: TestResource.Response.multipleSectionsJSONFilename)
+        
+        // let's pass a non existing section name
+        let sectionName = "non-existing-section-name"
+        
+        // create mock delegate
+        let del = MockResponseParserDelegate()
+        del.shouldParseResultsInSection = { name in
+            return name.lowercased() == sectionName
+        }
+        self.responseParser.delegate = del
+        
+        do {
+            let response = try responseParser.parse(autocompleteResponseData: data)
+            
+            XCTAssertEqual(response.sections.count, 0, "Results should be empty if the specified section doesn't exist within the JSON response.")
+        } catch {
+            XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
+        }
+    }
 }

--- a/UserApplication/AppDelegate.swift
+++ b/UserApplication/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CIOAutocompleteDelegate, 
         // set the data source to customize the look and feel of the UI
         viewController.dataSource = self
         
-        let bgColor = UIColor(colorLiteralRed: 67/255.0, green: 152/255.0, blue: 234/255.0, alpha: 1.0)
+        let bgColor = UIColor(red: 67/255.0, green: 152/255.0, blue: 234/255.0, alpha: 1.0)
         
         // embed it in the navigation controller
         let navigationController = UINavigationController(rootViewController: viewController)
@@ -112,8 +112,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CIOAutocompleteDelegate, 
     }
     
     func styleResultCell(cell: UITableViewCell, indexPath: IndexPath, in autocompleteController: CIOAutocompleteViewController) {
-        let val: Float = 0.97
-        cell.backgroundColor = UIColor(colorLiteralRed: val, green: val, blue: val, alpha: 1.0)
+        let val: CGFloat = 0.97
+        cell.backgroundColor = UIColor(red: val, green: val, blue: val, alpha: 1.0)
     }
 
     var i = 1

--- a/UserApplication/AppDelegate.swift
+++ b/UserApplication/AppDelegate.swift
@@ -46,7 +46,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CIOAutocompleteDelegate, 
     func showAutocompleteViewControllerAsRoot() {
         // Instantiate the autocomplete controller
         let key = "key_AttLywTIsQjS0nao"
-//        let key = "CD06z4gVeqSXRiDL2ZNK"
+
         let viewController = CIOAutocompleteViewController(autocompleteKey: key)
 
         // set the delegate in order to react to various events
@@ -150,15 +150,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CIOAutocompleteDelegate, 
     // MARK: Parsing
     
     func autocompleteController(controller: CIOAutocompleteViewController, shouldParseResult result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool {
-        if result.value.contains("guitar"){
-            return false
-        }
-        
-        if let group = group, group.displayName.lowercased() == "food"{
-            return false
-        }
-        
         return true
+    }
+    
+    func autocompleteController(controller: CIOAutocompleteViewController, shouldParseResultsInSection sectionName: String) -> Bool {
+        return sectionName.lowercased() != "products"
     }
     
     // MARK: SearchBar


### PR DESCRIPTION
Implemented section filtering. User can now filter sections simply by implementing the following delegate method
`func autocompleteController(controller: CIOAutocompleteViewController, shouldParseResultsInSection sectionName: String) -> Bool`

