### PR TITLE
Datetime _dt parameter is now attached to every request

### DIFF
--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -95,6 +95,7 @@ struct Constants {
         static let baseURLString = "https://ac.cnstrc.com"
         static let trackStringFormat = "%@/%@/%@/%@"
         static let expectedStatusCode = 204
+        static let dateTime = "_dt"
     }
 
     struct TrackAutocomplete {
@@ -114,7 +115,6 @@ struct Constants {
         static let trigger = "tr"
         static let triggerType = "click"
         static let originalQuery = "original_query"
-        static let dateTime = "_dt"
         static let groupName = "group[group_name]"
         static let groupID = "group[group_id]"
     }

--- a/AutocompleteClient/FW/Logic/Query/Builder/RequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/RequestBuilder.swift
@@ -68,7 +68,7 @@ class RequestBuilder {
     }
     
     private func addDateQueryItem(queryItems items: inout QueryItemCollection){
-        let dateString = String(self.dateProvider.provideDate().timeIntervalSinceReferenceDate)
+        let dateString = String(Int(self.dateProvider.provideDate().timeIntervalSince1970 * 1000))
         items.add(URLQueryItem(name: Constants.Track.dateTime, value: dateString))
     }
 }

--- a/AutocompleteClient/FW/Logic/Query/Builder/RequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/RequestBuilder.swift
@@ -11,9 +11,11 @@ import Foundation
 class RequestBuilder {
 
     var queryItems = QueryItemCollection()
-
-    init(autocompleteKey: String) {
-        set(autocompleteKey: autocompleteKey)
+    var dateProvider: DateProvider
+    
+    init(autocompleteKey: String, dateProvider: DateProvider = CurrentTimeDateProvider()) {
+        self.dateProvider = dateProvider
+        self.set(autocompleteKey: autocompleteKey)
     }
 
     // There is no need to encode query parameters. Not sure about those in the URL path string.
@@ -53,6 +55,9 @@ class RequestBuilder {
         let versionString = Constants.versionString()
         allQueryItems.add(URLQueryItem(name: "c", value: versionString))
         
+        // attach date
+        self.addDateQueryItem(queryItems: &allQueryItems)
+        
         urlComponents.queryItems = allQueryItems.all()
 
         let url = urlComponents.url!
@@ -60,5 +65,10 @@ class RequestBuilder {
         request.httpMethod = getHttpMethod()
         
         return request
+    }
+    
+    private func addDateQueryItem(queryItems items: inout QueryItemCollection){
+        let dateString = String(self.dateProvider.provideDate().timeIntervalSinceReferenceDate)
+        items.add(URLQueryItem(name: Constants.Track.dateTime, value: dateString))
     }
 }

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackAutocompleteClickRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackAutocompleteClickRequestBuilder.swift
@@ -57,15 +57,10 @@ class TrackAutocompleteClickRequestBuilder: RequestBuilder {
 
     override func addAdditionalQueryItems() {
         addTriggerQueryItem()
-        addDateQueryItem()
     }
 
     private func addTriggerQueryItem() {
         queryItems.add(URLQueryItem(name: Constants.TrackAutocompleteResultClicked.trigger, value: Constants.TrackAutocompleteResultClicked.triggerType))
-    }
-
-    private func addDateQueryItem() {
-        queryItems.add(URLQueryItem(name: Constants.TrackAutocompleteResultClicked.dateTime, value: String(Date().millisecondsSince1970)))
     }
 
 }

--- a/AutocompleteClientTests/Logic/Query/Builder/TrackConversionRequestBuilderTests.swift
+++ b/AutocompleteClientTests/Logic/Query/Builder/TrackConversionRequestBuilderTests.swift
@@ -34,7 +34,10 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let tracker = CIOConversionTrackData(searchTerm: searchTerm)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
+        let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
+        
         XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertTrue(request.url!.absoluteString.contains("_dt=\(requestDate)"), "URL should contain the request date")
         XCTAssertTrue(request.url!.absoluteString.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_key=\(testACKey)"), "URL should contain the autocomplete key.")
         XCTAssertTrue(request.url!.absoluteString.contains("c=cioios-"), "URL should contain the version string.")
@@ -44,7 +47,10 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let tracker = CIOConversionTrackData(searchTerm: searchTerm, itemName: itemName)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
+        let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
+        
         XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertTrue(request.url!.absoluteString.contains("_dt=\(requestDate)"), "URL should contain the request date")
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_key=\(testACKey)"), "URL should contain the autocomplete key.")
         XCTAssertTrue(request.url!.absoluteString.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(request.url!.absoluteString.contains("item=\(encodedItemName)"), "URL should contain the item name.")
@@ -54,9 +60,12 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let tracker = CIOConversionTrackData(searchTerm: searchTerm, sectionName: sectionName)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
+        let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
+        
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_key=\(testACKey)"), "URL should contain the autocomplete key.")
         XCTAssertTrue(request.url!.absoluteString.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(request.url!.absoluteString.contains("_dt=\(requestDate)"), "URL should contain the request date")
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
     }
     
@@ -64,21 +73,27 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let tracker = CIOConversionTrackData(searchTerm: searchTerm, revenue: revenue)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
+        let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
+        
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertTrue(request.url!.absoluteString.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_key=\(testACKey)"), "URL should contain the autocomplete key.")
         XCTAssertTrue(request.url!.absoluteString.contains("revenue=\(revenue)"), "URL should contain the revenue parameter.")
         XCTAssertTrue(request.url!.absoluteString.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(request.url!.absoluteString.contains("_dt=\(requestDate)"), "URL should contain the request date")
     }
 
     func testTrackConversionBuilder_AllFields() {
         let tracker = CIOConversionTrackData(searchTerm: searchTerm, itemName: itemName, sectionName: sectionName, revenue: revenue)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
+        let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
+        
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertTrue(request.url!.absoluteString.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_key=\(testACKey)"), "URL should contain the autocomplete key.")
         XCTAssertTrue(request.url!.absoluteString.contains("item=\(encodedItemName)"), "URL should contain the item name.")
+        XCTAssertTrue(request.url!.absoluteString.contains("_dt=\(requestDate)"), "URL should contain the request date")
         XCTAssertTrue(request.url!.absoluteString.contains("revenue=\(revenue)"), "URL should contain the revenue parameter.")
         XCTAssertTrue(request.url!.absoluteString.contains("autocomplete_section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
         XCTAssertTrue(request.url!.absoluteString.contains("c=cioios-"), "URL should contain the version string.")


### PR DESCRIPTION
- Moved _dt constant to Track constants structure.
- Moved adding date query item from the TrackAutocompleteClickRequestBuilder to the superclass.
- Added track conversion test assertions that test whether the request contains the current date. We're pulling the date from the url.components which is perfectly fine. I've created a dateProvider property inside the RequestBuilder so we can test whether the dates match, but I don't think that's a priority atm.