### PR TITLE
Implemented delegate method that allow customization of number of group items to be displayed

### DIFF
--- a/AutocompleteClient/FW/API/Parser/CIOResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/CIOResponseParser.swift
@@ -105,7 +105,7 @@ struct CIOResponseParser: AbstractResponseParser {
     }
     
     fileprivate func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int{
-        return self.delegate?.maximumNumberOfResultsForItem(result: result, at: index) ?? Int.max
+        return self.delegate?.maximumGroupsShownPerResult(result: result, at: index) ?? Int.max
     }
     
     fileprivate func delegateFilter(_ result: CIOAutocompleteResult, _ group: CIOGroup?) -> Bool?{

--- a/AutocompleteClient/FW/API/Parser/CIOResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/CIOResponseParser.swift
@@ -67,7 +67,7 @@ struct CIOResponseParser: AbstractResponseParser {
                             
                             // If the base result is filtered out, we don't show
                             // the group search options.
-                            if let shouldParseResult = self.delegateFilter(autocompleteResult, nil), shouldParseResult == false{
+                            if let shouldParseResult = self.delegateShouldParseResult(autocompleteResult, nil), shouldParseResult == false{
                                 return []
                             }
                             
@@ -80,14 +80,14 @@ struct CIOResponseParser: AbstractResponseParser {
                             }
                             
                             if let groups = autocompleteResult.groups{
-                                let maximumNumberOfGroupItems = self.maximumNumberOfResultsForItem(result: autocompleteResult, at: index)
+                                let maximumNumberOfGroupItems = self.delegateMaximumGroupsShownPerResult(result: autocompleteResult, at: index)
                                 
                                 groupLoop: for group in groups{
                                     if itemsInGroups.count >= maximumNumberOfGroupItems{
                                         break groupLoop
                                     }
                                     
-                                    if let shouldParseResultInGroup = self.delegateFilter(autocompleteResult, group){
+                                    if let shouldParseResultInGroup = self.delegateShouldParseResult(autocompleteResult, group){
                                         if shouldParseResultInGroup{
                                             // method implemented by the delegate and returns true
                                             parseItemHandler(group)
@@ -104,11 +104,11 @@ struct CIOResponseParser: AbstractResponseParser {
                         })
     }
     
-    fileprivate func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int{
+    fileprivate func delegateMaximumGroupsShownPerResult(result: CIOAutocompleteResult, at index: Int) -> Int{
         return self.delegate?.maximumGroupsShownPerResult(result: result, at: index) ?? Int.max
     }
     
-    fileprivate func delegateFilter(_ result: CIOAutocompleteResult, _ group: CIOGroup?) -> Bool?{
+    fileprivate func delegateShouldParseResult(_ result: CIOAutocompleteResult, _ group: CIOGroup?) -> Bool?{
         return self.delegate?.shouldParseResult(result: result, inGroup: group)
     }
 }

--- a/AutocompleteClient/FW/API/Parser/ResponseParserDelegate.swift
+++ b/AutocompleteClient/FW/API/Parser/ResponseParserDelegate.swift
@@ -11,4 +11,5 @@ import Foundation
 public protocol ResponseParserDelegate: class{
     func shouldParseResult(result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool?
     func shouldParseResults(inSectionWithName name: String) -> Bool?
+    func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int
 }

--- a/AutocompleteClient/FW/API/Parser/ResponseParserDelegate.swift
+++ b/AutocompleteClient/FW/API/Parser/ResponseParserDelegate.swift
@@ -11,5 +11,5 @@ import Foundation
 public protocol ResponseParserDelegate: class{
     func shouldParseResult(result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool?
     func shouldParseResults(inSectionWithName name: String) -> Bool?
-    func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int
+    func maximumGroupsShownPerResult(result: CIOAutocompleteResult, at index: Int) -> Int
 }

--- a/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
+++ b/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
@@ -445,7 +445,7 @@ extension CIOAutocompleteViewController: ResponseParserDelegate {
         return self.delegate?.autocompleteController?(controller: self, shouldParseResultsInSection: name) ?? name.isSearchSuggestionString()
     }
     
-    public func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int{
-        return self.delegate?.autocompleteController?(controller: self, maximumNumberOfGroupsForItem: result, itemIndex: index) ?? (index == 0 ? 2 : 0)
+    public func maximumGroupsShownPerResult(result: CIOAutocompleteResult, at index: Int) -> Int {
+        return self.delegate?.autocompleteController?(controller: self, maximumGroupsShownPerResult: result, itemIndex: index) ?? (index == 0 ? 2 : 0)
     }
 }

--- a/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
+++ b/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
@@ -444,4 +444,8 @@ extension CIOAutocompleteViewController: ResponseParserDelegate {
     public func shouldParseResults(inSectionWithName name: String) -> Bool? {
         return self.delegate?.autocompleteController?(controller: self, shouldParseResultsInSection: name) ?? name.isSearchSuggestionString()
     }
+    
+    public func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int{
+        return self.delegate?.autocompleteController?(controller: self, maximumNumberOfGroupsForItem: result, itemIndex: index) ?? (index == 0 ? 2 : 0)
+    }
 }

--- a/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
+++ b/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
@@ -63,6 +63,16 @@ public protocol CIOAutocompleteDelegate: class{
     optional func autocompleteController(controller: CIOAutocompleteViewController, shouldParseResult result: CIOAutocompleteResult, inGroup group: CIOGroup?) -> Bool
     
     /**
+      Maximum number of items in group to be displayed for an item at index. Does not get called for the base item(with nil group). By default, 2 items are shown for the first item(itemIndex=0) and 0 for every other.
+     
+     - parameter controller: A CIOAutocompleteViewController in which the results are shown.
+     - parameter item: Item to be displayed.
+     - parameter itemIndex: Index of an item being displayed.
+     */
+    @objc
+    optional func autocompleteController(controller: CIOAutocompleteViewController, maximumNumberOfGroupsForItem item: CIOAutocompleteResult, itemIndex: Int) -> Int
+    
+    /**
      Called if an error occurs.
      
      - parameter controller: A CIOAutocompleteViewController in which the selection occurred.

--- a/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
+++ b/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
@@ -70,7 +70,7 @@ public protocol CIOAutocompleteDelegate: class{
      - parameter itemIndex: Index of an item being displayed.
      */
     @objc
-    optional func autocompleteController(controller: CIOAutocompleteViewController, maximumNumberOfGroupsForItem item: CIOAutocompleteResult, itemIndex: Int) -> Int
+    optional func autocompleteController(controller: CIOAutocompleteViewController, maximumGroupsShownPerResult result: CIOAutocompleteResult, itemIndex: Int) -> Int
     
     /**
      Called if an error occurs.

--- a/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
+++ b/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
@@ -21,4 +21,8 @@ class MockResponseParserDelegate: NSObject, ResponseParserDelegate {
     func shouldParseResults(inSectionWithName name: String) -> Bool?{
         return self.shouldParseResultsInSection?(name)
     }
+    
+    func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int {
+        return 1
+    }
 }

--- a/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
+++ b/AutocompleteClientTests/Logic/Result/MockResponseParserDelegate.swift
@@ -22,7 +22,8 @@ class MockResponseParserDelegate: NSObject, ResponseParserDelegate {
         return self.shouldParseResultsInSection?(name)
     }
     
-    func maximumNumberOfResultsForItem(result: CIOAutocompleteResult, at index: Int) -> Int {
+    func maximumGroupsShownPerResult(result: CIOAutocompleteResult, at index: Int) -> Int {
         return 1
     }
+
 }

--- a/AutocompleteClientTests/Logic/Result/ResultParserTests.swift
+++ b/AutocompleteClientTests/Logic/Result/ResultParserTests.swift
@@ -123,32 +123,6 @@ class ResultParserTests: XCTestCase {
         }
     }
     
-    func test_ParsingValidJSONReturnsGroupResultsOnlyForFirstItem_IfDelegateMethodNotImplemented(){
-        let data = TestResource.load(name: TestResource.Response.multipleSectionsJSONFilename)
-        
-        // create mock delegate
-        let del = MockResponseParserDelegate()
-        del.shouldParseResultInGroup = nil
-        responseParser.delegate = del
-        
-        do {
-            let response = try responseParser.parse(autocompleteResponseData: data)
-            let searchSuggestions = response.getSearchSuggestions()!
-            
-            let firstItemResult = searchSuggestions.first!.autocompleteResult
-            
-            let resultsContainingFirstItem = searchSuggestions.filter({ item in item.autocompleteResult == firstItemResult })
-            XCTAssertGreaterThan(resultsContainingFirstItem.count, 1, "There should be more than one result returned for the first item.")
-            
-            let resultsContainingNonNilGroupResults = searchSuggestions.filter({ item in item.autocompleteResult != firstItemResult })
-                                                                       .filter{ $0.group != nil }
-            
-            XCTAssertEqual(resultsContainingNonNilGroupResults.count, 0, "There should be no items with non nil group past the first item parsed.")
-        } catch {
-            XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
-        }
-    }
-    
     func test_ParsingValidJSONReturnsGroupResultsForMultipleItems_IfDelegateMethodReturnsTrue(){
         let data = TestResource.load(name: TestResource.Response.multipleSectionsJSONFilename)
         

--- a/UserApplication/AppDelegate.swift
+++ b/UserApplication/AppDelegate.swift
@@ -209,6 +209,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CIOAutocompleteDelegate, 
         }
     }
 
+//    func autocompleteController(controller: CIOAutocompleteViewController, maximumNumberOfGroupsForItem item: CIOAutocompleteResult, itemIndex: Int) -> Int{
+//        return 3
+//    }
+    
     func autocompleteController(controller: CIOAutocompleteViewController, didPerformSearch searchTerm: String) {
         print("Search performed for term \(searchTerm)")
     }


### PR DESCRIPTION
One test has been deleted. It was testing the logic of number of parsed group items being returned. We now allow for customization of this parameter, therefore this test can go.