### PR TITLE
Tracking naming cleanup/consistency

### DIFF
--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		088F7D19210FA39A005B9FB4 /* TrackInputFocusRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D17210FA399005B9FB4 /* TrackInputFocusRequestBuilder.swift */; };
 		088F7D1A210FA39A005B9FB4 /* TrackSessionStartRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D18210FA39A005B9FB4 /* TrackSessionStartRequestBuilder.swift */; };
 		088F7D1C210FA3B4005B9FB4 /* CIOSessionManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D1B210FA3B4005B9FB4 /* CIOSessionManagerDelegate.swift */; };
-		088F7D1E210FA3C6005B9FB4 /* CIOInputFocusTrackData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D1D210FA3C6005B9FB4 /* CIOInputFocusTrackData.swift */; };
+		088F7D1E210FA3C6005B9FB4 /* CIOTrackInputFocusData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D1D210FA3C6005B9FB4 /* CIOTrackInputFocusData.swift */; };
 		088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D24210FA43C005B9FB4 /* DateProvider.swift */; };
 		088F7D27210FA43C005B9FB4 /* CurrentTimeDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088F7D25210FA43C005B9FB4 /* CurrentTimeDateProvider.swift */; };
 		F144AB651F60BD1800B2FB46 /* AutocompleteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F144AB641F60BD1800B2FB46 /* AutocompleteConfig.swift */; };
@@ -19,7 +19,7 @@
 		F192DDEA1F5F10D500114C8C /* TrackAutocompleteClickRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F192DDE91F5F10D500114C8C /* TrackAutocompleteClickRequestBuilder.swift */; };
 		F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F192DDED1F5F123400114C8C /* RequestBuilder.swift */; };
 		F19E289D1F5F1DBF0022C814 /* Date+MillisecondsSince1970.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E289C1F5F1DBF0022C814 /* Date+MillisecondsSince1970.swift */; };
-		F19E28A31F5F220B0022C814 /* CIOAutocompleteClickTrackData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E28A21F5F220B0022C814 /* CIOAutocompleteClickTrackData.swift */; };
+		F19E28A31F5F220B0022C814 /* CIOTrackAutocompleteClickData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E28A21F5F220B0022C814 /* CIOTrackAutocompleteClickData.swift */; };
 		F19E28A51F5F42830022C814 /* TrackConversionRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E28A41F5F42830022C814 /* TrackConversionRequestBuilder.swift */; };
 		F1B17CB21F58E5830015FF62 /* AutocompleteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B17CB11F58E5830015FF62 /* AutocompleteResult.swift */; };
 		F1C557411F5F67CA0040D6AD /* CIOHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C557401F5F67CA0040D6AD /* CIOHighlighterTests.swift */; };
@@ -96,7 +96,7 @@
 		F650154B1F587213008E50C0 /* CIOStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F650154A1F587213008E50C0 /* CIOStyle.swift */; };
 		F650154E1F58724B008E50C0 /* UIColor+RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = F650154D1F58724B008E50C0 /* UIColor+RGB.swift */; };
 		F6548834208633E20044E403 /* NSAttributedString+Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6548833208633E20044E403 /* NSAttributedString+Build.swift */; };
-		F672F6BA20ABE9EC00EA1525 /* CIOConversionTrackData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E28A61F5F44C30022C814 /* CIOConversionTrackData.swift */; };
+		F672F6BA20ABE9EC00EA1525 /* CIOTrackConversionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19E28A61F5F44C30022C814 /* CIOTrackConversionData.swift */; };
 		F674157B204D489B004F313B /* MockResponseParserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F674157A204D489B004F313B /* MockResponseParserDelegate.swift */; };
 		F67BFC9320B8457B00986557 /* UIView+FindSubview.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67BFC9220B8457B00986557 /* UIView+FindSubview.swift */; };
 		F67BFC9520B845D300986557 /* UISearchBar+TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67BFC9420B845D300986557 /* UISearchBar+TextField.swift */; };
@@ -132,10 +132,10 @@
 		F6D2E9C120DBDCCA007F8761 /* response_json_single_result.json in Resources */ = {isa = PBXBuildFile; fileRef = F6D2E9C020DBDCCA007F8761 /* response_json_single_result.json */; };
 		F6D2E9C420DBDDBB007F8761 /* Data+ToJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E9C320DBDDBB007F8761 /* Data+ToJSON.swift */; };
 		F6D2E9CA20E15190007F8761 /* HasSectionName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E9C920E15190007F8761 /* HasSectionName.swift */; };
-		F6D2E9CC20E21022007F8761 /* CIOSearchResultsLoadedTrackData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E9CB20E21022007F8761 /* CIOSearchResultsLoadedTrackData.swift */; };
+		F6D2E9CC20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */; };
 		F6D2E9CE20E210BD007F8761 /* TrackSearchResultsLoadedRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D2E9CD20E210BD007F8761 /* TrackSearchResultsLoadedRequestBuilder.swift */; };
 		F6DF7B9220849C4300A7CDAD /* TrackSearchRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DF7B9120849C4300A7CDAD /* TrackSearchRequestBuilder.swift */; };
-		F6DF7B9420849E8D00A7CDAD /* CIOSearchTrackData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DF7B9320849E8D00A7CDAD /* CIOSearchTrackData.swift */; };
+		F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DF7B9320849E8D00A7CDAD /* CIOTrackSearchData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,7 +166,7 @@
 		088F7D17210FA399005B9FB4 /* TrackInputFocusRequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackInputFocusRequestBuilder.swift; sourceTree = "<group>"; };
 		088F7D18210FA39A005B9FB4 /* TrackSessionStartRequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackSessionStartRequestBuilder.swift; sourceTree = "<group>"; };
 		088F7D1B210FA3B4005B9FB4 /* CIOSessionManagerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIOSessionManagerDelegate.swift; sourceTree = "<group>"; };
-		088F7D1D210FA3C6005B9FB4 /* CIOInputFocusTrackData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIOInputFocusTrackData.swift; sourceTree = "<group>"; };
+		088F7D1D210FA3C6005B9FB4 /* CIOTrackInputFocusData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIOTrackInputFocusData.swift; sourceTree = "<group>"; };
 		088F7D24210FA43C005B9FB4 /* DateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DateProvider.swift; path = AutocompleteClient/FW/Logic/Session/Date/DateProvider.swift; sourceTree = SOURCE_ROOT; };
 		088F7D25210FA43C005B9FB4 /* CurrentTimeDateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CurrentTimeDateProvider.swift; path = AutocompleteClient/FW/Logic/Session/Date/CurrentTimeDateProvider.swift; sourceTree = SOURCE_ROOT; };
 		F144AB641F60BD1800B2FB46 /* AutocompleteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteConfig.swift; sourceTree = "<group>"; };
@@ -175,9 +175,9 @@
 		F192DDE91F5F10D500114C8C /* TrackAutocompleteClickRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackAutocompleteClickRequestBuilder.swift; sourceTree = "<group>"; };
 		F192DDED1F5F123400114C8C /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		F19E289C1F5F1DBF0022C814 /* Date+MillisecondsSince1970.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+MillisecondsSince1970.swift"; sourceTree = "<group>"; };
-		F19E28A21F5F220B0022C814 /* CIOAutocompleteClickTrackData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOAutocompleteClickTrackData.swift; sourceTree = "<group>"; };
+		F19E28A21F5F220B0022C814 /* CIOTrackAutocompleteClickData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOTrackAutocompleteClickData.swift; sourceTree = "<group>"; };
 		F19E28A41F5F42830022C814 /* TrackConversionRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackConversionRequestBuilder.swift; sourceTree = "<group>"; };
-		F19E28A61F5F44C30022C814 /* CIOConversionTrackData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOConversionTrackData.swift; sourceTree = "<group>"; };
+		F19E28A61F5F44C30022C814 /* CIOTrackConversionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOTrackConversionData.swift; sourceTree = "<group>"; };
 		F1B17CB11F58E5830015FF62 /* AutocompleteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteResult.swift; sourceTree = "<group>"; };
 		F1C557401F5F67CA0040D6AD /* CIOHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOHighlighterTests.swift; sourceTree = "<group>"; };
 		F1C557421F605C910040D6AD /* TrackAutocompleteClickRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackAutocompleteClickRequestBuilderTests.swift; sourceTree = "<group>"; };
@@ -293,10 +293,10 @@
 		F6D2E9C020DBDCCA007F8761 /* response_json_single_result.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = response_json_single_result.json; sourceTree = "<group>"; };
 		F6D2E9C320DBDDBB007F8761 /* Data+ToJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+ToJSON.swift"; sourceTree = "<group>"; };
 		F6D2E9C920E15190007F8761 /* HasSectionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasSectionName.swift; sourceTree = "<group>"; };
-		F6D2E9CB20E21022007F8761 /* CIOSearchResultsLoadedTrackData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOSearchResultsLoadedTrackData.swift; sourceTree = "<group>"; };
+		F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOTrackSearchResultsLoadedData.swift; sourceTree = "<group>"; };
 		F6D2E9CD20E210BD007F8761 /* TrackSearchResultsLoadedRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSearchResultsLoadedRequestBuilder.swift; sourceTree = "<group>"; };
 		F6DF7B9120849C4300A7CDAD /* TrackSearchRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSearchRequestBuilder.swift; sourceTree = "<group>"; };
-		F6DF7B9320849E8D00A7CDAD /* CIOSearchTrackData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOSearchTrackData.swift; sourceTree = "<group>"; };
+		F6DF7B9320849E8D00A7CDAD /* CIOTrackSearchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOTrackSearchData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -379,11 +379,11 @@
 		F19E28A11F5F22010022C814 /* Track */ = {
 			isa = PBXGroup;
 			children = (
-				F19E28A21F5F220B0022C814 /* CIOAutocompleteClickTrackData.swift */,
-				F19E28A61F5F44C30022C814 /* CIOConversionTrackData.swift */,
-				088F7D1D210FA3C6005B9FB4 /* CIOInputFocusTrackData.swift */,
-				F6D2E9CB20E21022007F8761 /* CIOSearchResultsLoadedTrackData.swift */,
-				F6DF7B9320849E8D00A7CDAD /* CIOSearchTrackData.swift */,
+				F19E28A21F5F220B0022C814 /* CIOTrackAutocompleteClickData.swift */,
+				F19E28A61F5F44C30022C814 /* CIOTrackConversionData.swift */,
+				088F7D1D210FA3C6005B9FB4 /* CIOTrackInputFocusData.swift */,
+				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
+				F6DF7B9320849E8D00A7CDAD /* CIOTrackSearchData.swift */,
 				F6D2E9C920E15190007F8761 /* HasSectionName.swift */,
 			);
 			path = Track;
@@ -1355,7 +1355,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F672F6BA20ABE9EC00EA1525 /* CIOConversionTrackData.swift in Sources */,
+				F672F6BA20ABE9EC00EA1525 /* CIOTrackConversionData.swift in Sources */,
 				F1F68DE91F58D23D00B42602 /* AbstractConstructorDataSource.swift in Sources */,
 				F1B17CB21F58E5830015FF62 /* AutocompleteResult.swift in Sources */,
 				F65015481F586A42008E50C0 /* UIView+FadeInOut.swift in Sources */,
@@ -1364,7 +1364,7 @@
 				F67BFC9520B845D300986557 /* UISearchBar+TextField.swift in Sources */,
 				F6B220ED209C692D003A5D48 /* CustomSearchController.swift in Sources */,
 				F6DF7B9220849C4300A7CDAD /* TrackSearchRequestBuilder.swift in Sources */,
-				F6DF7B9420849E8D00A7CDAD /* CIOSearchTrackData.swift in Sources */,
+				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
 				F19E28A51F5F42830022C814 /* TrackConversionRequestBuilder.swift in Sources */,
@@ -1372,10 +1372,10 @@
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,
 				F1F68DE51F58BBA400B42602 /* String+CharacterSetIterator.swift in Sources */,
-				F19E28A31F5F220B0022C814 /* CIOAutocompleteClickTrackData.swift in Sources */,
+				F19E28A31F5F220B0022C814 /* CIOTrackAutocompleteClickData.swift in Sources */,
 				F650154B1F587213008E50C0 /* CIOStyle.swift in Sources */,
 				F63808EF1F5D2F5B00C3B322 /* AutocompleteViewModelSection.swift in Sources */,
-				F6D2E9CC20E21022007F8761 /* CIOSearchResultsLoadedTrackData.swift in Sources */,
+				F6D2E9CC20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift in Sources */,
 				F650154E1F58724B008E50C0 /* UIColor+RGB.swift in Sources */,
 				F60BEA1A1F571956008F0053 /* CIOAutocompleteDelegate.swift in Sources */,
 				F19E289D1F5F1DBF0022C814 /* Date+MillisecondsSince1970.swift in Sources */,
@@ -1408,7 +1408,7 @@
 				F69C2C9D207D1C9C0060B2B9 /* String+SearchSuggestionsSection.swift in Sources */,
 				F63808FB1F5D49AF00C3B322 /* TaskResponse.swift in Sources */,
 				F1F68DE31F58B8BB00B42602 /* CIOError.swift in Sources */,
-				088F7D1E210FA3C6005B9FB4 /* CIOInputFocusTrackData.swift in Sources */,
+				088F7D1E210FA3C6005B9FB4 /* CIOTrackInputFocusData.swift in Sources */,
 				F62510C82052CC6B0040E3DF /* CIOSessionManager.swift in Sources */,
 				F68A73131F56E5FB00FA4D1B /* String+Trim.swift in Sources */,
 				F60BEA201F5726CB008F0053 /* EmptyScreenView.swift in Sources */,

--- a/AutocompleteClient/FW/Logic/Conversion/CIOTracker.swift
+++ b/AutocompleteClient/FW/Logic/Conversion/CIOTracker.swift
@@ -10,11 +10,11 @@ import UIKit
 
 public protocol CIOTracker: class{
 
-    func trackAutocompleteClick(for tracker: CIOAutocompleteClickTrackData, completionHandler: TrackingCompletionHandler?)
+    func trackAutocompleteClick(for tracker: CIOTrackAutocompleteClickData, completionHandler: TrackingCompletionHandler?)
     
-    func trackConversion(for tracker: CIOConversionTrackData, completionHandler: TrackingCompletionHandler?)
+    func trackConversion(for tracker: CIOTrackConversionData, completionHandler: TrackingCompletionHandler?)
     
-    func trackSearch(for tracker: CIOSearchTrackData, completionHandler: TrackingCompletionHandler?)
+    func trackSearch(for tracker: CIOTrackSearchData, completionHandler: TrackingCompletionHandler?)
     
-    func trackSearchResultsLoaded(for tracker: CIOSearchResultsLoadedTrackData, completionHandler: TrackingCompletionHandler?)
+    func trackSearchResultsLoaded(for tracker: CIOTrackSearchResultsLoadedData, completionHandler: TrackingCompletionHandler?)
 }

--- a/AutocompleteClient/FW/Logic/Conversion/CIOTracking.swift
+++ b/AutocompleteClient/FW/Logic/Conversion/CIOTracking.swift
@@ -31,13 +31,13 @@ public class CIOTracking: NSObject {
         self.tracker?.trackConversion(for: trackData, completionHandler: completionHandler)
     }
     
-    /// Track results loaded.
+    /// Track search results loaded.
     ///
     /// - Parameters:
     ///   - searchTerm: Search term that the user searched for
     ///   - resultCount: Number of results loaded
     ///   - completionHandler: The callback to execute on completion.
-    public func trackResultsLoaded(searchTerm: String, resultCount: Int, completionHandler: TrackingCompletionHandler? = nil){
+    public func trackSearchResultsLoaded(searchTerm: String, resultCount: Int, completionHandler: TrackingCompletionHandler? = nil){
         let data = CIOTrackSearchResultsLoadedData(searchTerm: searchTerm, resultCount: resultCount )
         self.tracker?.trackSearchResultsLoaded(for: data, completionHandler: completionHandler)
     }

--- a/AutocompleteClient/FW/Logic/Conversion/CIOTracking.swift
+++ b/AutocompleteClient/FW/Logic/Conversion/CIOTracking.swift
@@ -27,7 +27,7 @@ public class CIOTracking: NSObject {
     ///   - searchTerm: Search term that the user searched for. If nil is passed, 'TERM_UNKNOWN' will be sent to the server.
     ///   - completionHandler: The callback to execute on completion.
     public func trackConversion(itemID: String, revenue: Int?, searchTerm: String?, completionHandler: TrackingCompletionHandler? = nil){
-        let trackData = CIOConversionTrackData(searchTerm: (searchTerm ?? "TERM_UNKNOWN"), itemID: itemID, sectionName: nil, revenue: revenue)
+        let trackData = CIOTrackConversionData(searchTerm: (searchTerm ?? "TERM_UNKNOWN"), itemID: itemID, sectionName: nil, revenue: revenue)
         self.tracker?.trackConversion(for: trackData, completionHandler: completionHandler)
     }
     
@@ -38,7 +38,7 @@ public class CIOTracking: NSObject {
     ///   - resultCount: Number of results loaded
     ///   - completionHandler: The callback to execute on completion.
     public func trackResultsLoaded(searchTerm: String, resultCount: Int, completionHandler: TrackingCompletionHandler? = nil){
-        let data = CIOSearchResultsLoadedTrackData(searchTerm: searchTerm, resultCount: resultCount )
+        let data = CIOTrackSearchResultsLoadedData(searchTerm: searchTerm, resultCount: resultCount )
         self.tracker?.trackSearchResultsLoaded(for: data, completionHandler: completionHandler)
     }
     

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackAutocompleteClickRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackAutocompleteClickRequestBuilder.swift
@@ -15,7 +15,7 @@ class TrackAutocompleteClickRequestBuilder: RequestBuilder {
         return self.queryItems.all().contains { (item) -> Bool in return item.name == Constants.TrackAutocomplete.autocompleteSection }
     }
 
-    init(tracker: CIOAutocompleteClickTrackData, autocompleteKey: String) {
+    init(tracker: CIOTrackAutocompleteClickData, autocompleteKey: String) {
         super.init(autocompleteKey: autocompleteKey)
         set(itemName: tracker.clickedItemName)
         set(originalQuery: tracker.searchTerm)

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackConversionRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackConversionRequestBuilder.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class TrackConversionRequestBuilder: RequestBuilder {
 
-    init(tracker: CIOConversionTrackData, autocompleteKey: String) {
+    init(tracker: CIOTrackConversionData, autocompleteKey: String) {
         super.init(autocompleteKey: autocompleteKey)
         self.searchTerm = tracker.searchTerm
         set(itemID: tracker.itemID)

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackInputFocusRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackInputFocusRequestBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  InputFocusRequestBuilder.swift
+//  TrackInputFocusRequestBuilder.swift
 //  AutocompleteClient
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -10,7 +10,7 @@ import UIKit
 
 class TrackInputFocusRequestBuilder: RequestBuilder {
 
-    init(tracker: CIOInputFocusTrackData, autocompleteKey: String) {
+    init(tracker: CIOTrackInputFocusData, autocompleteKey: String) {
         super.init(autocompleteKey: autocompleteKey)
         
         if let term = tracker.searchTerm{

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackSearchRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackSearchRequestBuilder.swift
@@ -12,7 +12,7 @@ class TrackSearchRequestBuilder: RequestBuilder {
 
     let searchItem: String
     
-    init(trackData: CIOSearchTrackData, autocompleteKey: String){
+    init(trackData: CIOTrackSearchData, autocompleteKey: String){
         self.searchItem = trackData.itemName
         super.init(autocompleteKey: autocompleteKey)
         

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackSearchResultsLoadedRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackSearchResultsLoadedRequestBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  TrackResultsLoadedRequestBuilder.swift
+//  TrackSearchResultsLoadedRequestBuilder.swift
 //  AutocompleteClient
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -10,7 +10,7 @@ import Foundation
 
 class TrackSearchResultsLoadedRequestBuilder: RequestBuilder {
 
-    init(tracker: CIOSearchResultsLoadedTrackData, autocompleteKey: String) {
+    init(tracker: CIOTrackSearchResultsLoadedData, autocompleteKey: String) {
         super.init(autocompleteKey: autocompleteKey)
         
         self.set(searchTerm: tracker.searchTerm)

--- a/AutocompleteClient/FW/Logic/Query/Builder/TrackSessionStartRequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Query/Builder/TrackSessionStartRequestBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  SessionStartRequestBuilder.swift
+//  TrackSessionStartRequestBuilder.swift
 //  AutocompleteClient
 //
 //  Copyright © Constructor.io. All rights reserved.

--- a/AutocompleteClient/FW/Logic/Track/CIOTrackAutocompleteClickData.swift
+++ b/AutocompleteClient/FW/Logic/Track/CIOTrackAutocompleteClickData.swift
@@ -1,5 +1,5 @@
 //
-//  CIOAutocompleteClickTracker.swift
+//  CIOTrackAutocompleteClickData.swift
 //  Constructor.io
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -15,7 +15,7 @@ import Foundation
  - If specified, it will report the autocomplete click as a *select* type and should be used for all types of item clicks, which simply tracks a user selection on an autocomplete item.
  - Otherwise, it will report the autocomplete click as a *search* type, typically used when the clicked item is a search suggestion for tracking what users search (in addition to the *select* type).
  */
-public struct CIOAutocompleteClickTrackData: HasSectionName {
+public struct CIOTrackAutocompleteClickData: HasSectionName {
 
     public let searchTerm: String
     public let clickedItemName: String

--- a/AutocompleteClient/FW/Logic/Track/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Track/CIOTrackConversionData.swift
@@ -1,5 +1,5 @@
 //
-//  CIOConversionTracker.swift
+//  CIOTrackConversionData.swift
 //  Constructor.io
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -11,7 +11,7 @@ import Foundation
 /**
  Struct encapsulating the parameters that must/can be set set in order to track a conversion for an autocomplete.
  */
-public struct CIOConversionTrackData: HasSectionName {
+public struct CIOTrackConversionData: HasSectionName {
 
     public let searchTerm: String
     public let itemID: String?

--- a/AutocompleteClient/FW/Logic/Track/CIOTrackInputFocusData.swift
+++ b/AutocompleteClient/FW/Logic/Track/CIOTrackInputFocusData.swift
@@ -1,5 +1,5 @@
 //
-//  CIOInputFocusTrackData.swift
+//  CIOTrackInputFocusData.swift
 //  AutocompleteClient
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public struct CIOInputFocusTrackData{
+public struct CIOTrackInputFocusData{
     let searchTerm: String?
     
     init(searchTerm: String?){

--- a/AutocompleteClient/FW/Logic/Track/CIOTrackSearchData.swift
+++ b/AutocompleteClient/FW/Logic/Track/CIOTrackSearchData.swift
@@ -1,5 +1,5 @@
 //
-//  CIOSearchTrackData.swift
+//  CIOTrackSearchData.swift
 //  Constructor.io
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public struct CIOSearchTrackData {
+public struct CIOTrackSearchData {
     let searchTerm: String
     let itemName: String
 }

--- a/AutocompleteClient/FW/Logic/Track/CIOTrackSearchResultsLoadedData.swift
+++ b/AutocompleteClient/FW/Logic/Track/CIOTrackSearchResultsLoadedData.swift
@@ -1,5 +1,5 @@
 //
-//  CIOSearchResultsLoadedTrackData.swift
+//  CIOTrackSearchResultsLoadedData.swift
 //  AutocompleteClient
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CIOSearchResultsLoadedTrackData{
+public struct CIOTrackSearchResultsLoadedData{
     let searchTerm: String
     let resultCount: Int
     

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -67,7 +67,7 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
     /// - Parameters:
     ///   - tracker: The object containing the necessary and additional tracking parameters.
     ///   - completionHandler: The callback to execute on completion.
-    public func trackSearchResultsLoaded(for tracker: CIOSearchResultsLoadedTrackData, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackSearchResultsLoaded(for tracker: CIOTrackSearchResultsLoadedData, completionHandler: TrackingCompletionHandler? = nil) {
         let request = buildRequest(fromTracker: tracker)
         execute(request, completionHandler: completionHandler)
     }
@@ -77,7 +77,7 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
     /// - Parameters:
     ///   - tracker: The object containing the necessary and additional tracking parameters.
     ///   - completionHandler: The callback to execute on completion.
-    public func trackAutocompleteClick(for tracker: CIOAutocompleteClickTrackData, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackAutocompleteClick(for tracker: CIOTrackAutocompleteClickData, completionHandler: TrackingCompletionHandler? = nil) {
         let request = buildRequest(fromTracker: tracker)
         execute(request, completionHandler: completionHandler)
     }
@@ -87,7 +87,7 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
     /// - Parameters:
     ///   - tracker: The object containing the necessary and additional tracking parameters.
     ///   - completionHandler: The callback to execute on completion.
-    public func trackConversion(for tracker: CIOConversionTrackData, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackConversion(for tracker: CIOTrackConversionData, completionHandler: TrackingCompletionHandler? = nil) {
         let request = buildRequest(fromTracker: tracker)
         execute(request, completionHandler: completionHandler)
     }
@@ -97,7 +97,7 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
     /// - Parameters:
     ///   - tracker: The object containing the necessary and additional tracking parameters.
     ///   - completionHandler: The callback to execute on completion.
-    public func trackInputFocus(for tracker: CIOInputFocusTrackData, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackInputFocus(for tracker: CIOTrackInputFocusData, completionHandler: TrackingCompletionHandler? = nil) {
         let request = buildRequest(fromTracker: tracker)
         execute(request, completionHandler: completionHandler)
     }
@@ -112,12 +112,12 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
     /// - Parameters:
     ///   - tracker: The object containing the necessary and additional tracking parameters.
     ///   - completionHandler: The callback to execute on completion.
-    public func trackSearch(for tracker: CIOSearchTrackData, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackSearch(for tracker: CIOTrackSearchData, completionHandler: TrackingCompletionHandler? = nil) {
         let request = buildRequest(fromTracker: tracker)
         execute(request, completionHandler: completionHandler)
     }
     
-    private func buildRequest(fromTracker tracker: CIOInputFocusTrackData) -> URLRequest{
+    private func buildRequest(fromTracker tracker: CIOTrackInputFocusData) -> URLRequest{
         let requestBuilder = TrackInputFocusRequestBuilder(tracker: tracker, autocompleteKey: self.autocompleteKey)
         self.attachClientSessionAndClientID(requestBuilder: requestBuilder)
         return requestBuilder.getRequest()
@@ -129,31 +129,31 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
         return requestBuilder.getRequest()
     }
     
-    private func buildRequest(fromTracker tracker: CIOSearchResultsLoadedTrackData) -> URLRequest{
+    private func buildRequest(fromTracker tracker: CIOTrackSearchResultsLoadedData) -> URLRequest{
         let requestBuilder = TrackSearchResultsLoadedRequestBuilder(tracker: tracker, autocompleteKey: self.autocompleteKey)
         self.attachClientSessionAndClientID(requestBuilder: requestBuilder)
         return requestBuilder.getRequest()
     }
     
-    private func buildRequest(fromTracker tracker: CIOSearchTrackData) -> URLRequest{
+    private func buildRequest(fromTracker tracker: CIOTrackSearchData) -> URLRequest{
         let requestBuilder = TrackSearchRequestBuilder(trackData: tracker, autocompleteKey: self.autocompleteKey)
         self.attachClientSessionAndClientID(requestBuilder: requestBuilder)
         return requestBuilder.getRequest()
     }
     
-    private func buildRequest(fromTracker tracker: CIOConversionTrackData) -> URLRequest {
+    private func buildRequest(fromTracker tracker: CIOTrackConversionData) -> URLRequest {
         var trackData: HasSectionName = tracker
         self.attachDefaultSectionNameIfNeeded(&trackData)
         
-        let requestBuilder = TrackConversionRequestBuilder(tracker: trackData as! CIOConversionTrackData, autocompleteKey: self.autocompleteKey)
+        let requestBuilder = TrackConversionRequestBuilder(tracker: trackData as! CIOTrackConversionData, autocompleteKey: self.autocompleteKey)
         return requestBuilder.getRequest()
     }
 
-    private func buildRequest(fromTracker tracker: CIOAutocompleteClickTrackData) -> URLRequest {
+    private func buildRequest(fromTracker tracker: CIOTrackAutocompleteClickData) -> URLRequest {
         var trackData: HasSectionName = tracker
         self.attachDefaultSectionNameIfNeeded(&trackData)
         
-        let requestBuilder = TrackAutocompleteClickRequestBuilder(tracker: trackData as! CIOAutocompleteClickTrackData, autocompleteKey: self.autocompleteKey)
+        let requestBuilder = TrackAutocompleteClickRequestBuilder(tracker: trackData as! CIOTrackAutocompleteClickData, autocompleteKey: self.autocompleteKey)
         return requestBuilder.getRequest()
     }
 

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -92,7 +92,7 @@ public class ConstructorIO: AbstractConstructorDataSource, CIOTracker, CIOSessio
         execute(request, completionHandler: completionHandler)
     }
 
-    /// Track a conversion.
+    /// Track input focus.
     ///
     /// - Parameters:
     ///   - tracker: The object containing the necessary and additional tracking parameters.

--- a/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
+++ b/AutocompleteClient/FW/UI/CIOAutocompleteViewController.swift
@@ -350,18 +350,18 @@ extension CIOAutocompleteViewController:  UITableViewDelegate, UITableViewDataSo
         let sectionName = viewModel.getSectionName(atIndex: indexPath.section)
         
         // Run behavioural tracking 'select' on autocomplete result select
-        let selectTracker = CIOAutocompleteClickTrackData(searchTerm: viewModel.searchTerm, clickedItemName: result.autocompleteResult.value, sectionName: sectionName, group: result.group)
+        let selectTracker = CIOTrackAutocompleteClickData(searchTerm: viewModel.searchTerm, clickedItemName: result.autocompleteResult.value, sectionName: sectionName, group: result.group)
 
         // TODO: For now, ignore any errors
         constructorIO.trackAutocompleteClick(for: selectTracker)
 
         // Track search
-        let searchTrackData = CIOSearchTrackData(searchTerm: viewModel.searchTerm, itemName: result.autocompleteResult.value)
+        let searchTrackData = CIOTrackSearchData(searchTerm: viewModel.searchTerm, itemName: result.autocompleteResult.value)
         constructorIO.trackSearch(for: searchTrackData)
         
         // Run behavioural tracking 'search' if its an autocomplete suggestion
         if sectionName == "standard" {
-            let searchTracker = CIOAutocompleteClickTrackData(searchTerm: viewModel.searchTerm, clickedItemName: result.autocompleteResult.value)
+            let searchTracker = CIOTrackAutocompleteClickData(searchTerm: viewModel.searchTerm, clickedItemName: result.autocompleteResult.value)
             constructorIO.trackAutocompleteClick(for: searchTracker)
         }
 
@@ -413,12 +413,12 @@ extension CIOAutocompleteViewController: UISearchBarDelegate {
     
     public func searchBarSearchButtonClicked(_ searchBar: UISearchBar){
         // Track search
-        let searchTrackData = CIOSearchTrackData(searchTerm: viewModel.searchTerm, itemName: viewModel.searchTerm)
+        let searchTrackData = CIOTrackSearchData(searchTerm: viewModel.searchTerm, itemName: viewModel.searchTerm)
         self.constructorIO.trackSearch(for: searchTrackData)
     }
     
     public func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-        self.constructorIO.trackInputFocus(for: CIOInputFocusTrackData(searchTerm: searchBar.text))
+        self.constructorIO.trackInputFocus(for: CIOTrackInputFocusData(searchTerm: searchBar.text))
         return true
     }
 }

--- a/AutocompleteClientTests/Logic/Query/Builder/TrackAutocompleteClickRequestBuilderTests.swift
+++ b/AutocompleteClientTests/Logic/Query/Builder/TrackAutocompleteClickRequestBuilderTests.swift
@@ -36,7 +36,7 @@ class TrackAutocompleteClickRequestBuilderTests: XCTestCase {
     }
     
     private func initializeClickTrackDataRequestWithNoSectionName() -> URLRequest{
-        let tracker = CIOAutocompleteClickTrackData(searchTerm: searchTerm, clickedItemName: clickedItemName)
+        let tracker = CIOTrackAutocompleteClickData(searchTerm: searchTerm, clickedItemName: clickedItemName)
         builder = TrackAutocompleteClickRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         builder.dateProvider = self.dateProvider
         let request = builder.getRequest()
@@ -44,7 +44,7 @@ class TrackAutocompleteClickRequestBuilderTests: XCTestCase {
     }
     
     private func initializeClickTrackDataRequestWithSectionName() -> URLRequest{
-        let tracker = CIOAutocompleteClickTrackData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: sectionName)
+        let tracker = CIOTrackAutocompleteClickData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: sectionName)
         builder = TrackAutocompleteClickRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         builder.dateProvider = self.dateProvider
         let request = builder.getRequest()
@@ -97,7 +97,7 @@ class TrackAutocompleteClickRequestBuilderTests: XCTestCase {
         let groupPath = "path/to/group"
         let group = CIOGroup(displayName: groupName, groupID: groupID, path: groupPath)
         
-        let tracker = CIOAutocompleteClickTrackData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: group)
+        let tracker = CIOTrackAutocompleteClickData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: group)
         builder = TrackAutocompleteClickRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         
@@ -113,7 +113,7 @@ class TrackAutocompleteClickRequestBuilderTests: XCTestCase {
         let groupPath = "path/to/group"
         let group = CIOGroup(displayName: groupName, groupID: groupID, path: groupPath)
         
-        let tracker = CIOAutocompleteClickTrackData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: group)
+        let tracker = CIOTrackAutocompleteClickData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: group)
         builder = TrackAutocompleteClickRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         
@@ -124,7 +124,7 @@ class TrackAutocompleteClickRequestBuilderTests: XCTestCase {
     }
     
     func testTrackACClickBuilder_tappingOnItemWithNoGroup_DoesNotSendGroupIDAsQueryParameter() {
-        let tracker = CIOAutocompleteClickTrackData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: nil)
+        let tracker = CIOTrackAutocompleteClickData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: nil)
         builder = TrackAutocompleteClickRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         
@@ -135,7 +135,7 @@ class TrackAutocompleteClickRequestBuilderTests: XCTestCase {
     }
     
     func testTrackACClickBuilder_tappingOnItemWithNoGroup_DoesNotSendGroupNameAsQueryParameter() {
-        let tracker = CIOAutocompleteClickTrackData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: nil)
+        let tracker = CIOTrackAutocompleteClickData(searchTerm: searchTerm, clickedItemName: clickedItemName, sectionName: nil, group: nil)
         builder = TrackAutocompleteClickRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         

--- a/AutocompleteClientTests/Logic/Query/Builder/TrackConversionRequestBuilderTests.swift
+++ b/AutocompleteClientTests/Logic/Query/Builder/TrackConversionRequestBuilderTests.swift
@@ -31,7 +31,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     }
     
     func testTrackConversionBuilder_onlySearchTerm() {
-        let tracker = CIOConversionTrackData(searchTerm: searchTerm)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
@@ -44,7 +44,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     }
 
     func testTrackConversionBuilder_withItemName() {
-        let tracker = CIOConversionTrackData(searchTerm: searchTerm)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
@@ -56,7 +56,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     }
 
     func testTrackConversionBuilder_withSectionName() {
-        let tracker = CIOConversionTrackData(searchTerm: searchTerm, sectionName: sectionName)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm, sectionName: sectionName)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
@@ -69,7 +69,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     }
     
     func testTrackConversionBuilder_withRevenue() {
-        let tracker = CIOConversionTrackData(searchTerm: searchTerm, revenue: revenue)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm, revenue: revenue)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!
@@ -83,7 +83,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     }
 
     func testTrackConversionBuilder_withNoSectionSpecified_hasNoSectionName() {
-        let tracker = CIOConversionTrackData(searchTerm: searchTerm)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         
@@ -91,7 +91,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     }
     
     func testTrackConversionBuilder_AllFields() {
-        let tracker = CIOConversionTrackData(searchTerm: searchTerm, sectionName: sectionName, revenue: revenue)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm, sectionName: sectionName, revenue: revenue)
         builder = TrackConversionRequestBuilder(tracker: tracker, autocompleteKey: testACKey)
         let request = builder.getRequest()
         let requestDate = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)!.queryItems!.first { $0.name == "_dt" }!.value!

--- a/UserApplication/DetailsViewController.swift
+++ b/UserApplication/DetailsViewController.swift
@@ -37,7 +37,7 @@ class DetailsViewController: UIViewController {
         self.view.addSubview(button)
         self.buttonTrackConversion = button
         
-        button = self.createButton(title: "Track results loaded")
+        button = self.createButton(title: "Track search results loaded")
         button.addTarget(self, action: #selector(didTapOnButtonTrackResultsLoaded(_:)), for: .touchUpInside)
         self.view.addSubview(button)
         self.buttonTrackResultsLoaded = button
@@ -77,6 +77,6 @@ class DetailsViewController: UIViewController {
     
     func didTapOnButtonTrackResultsLoaded(_ sender: UIButton){
         let resultCount = 10
-        self.constructorIO.tracking.trackResultsLoaded(searchTerm: "a search term", resultCount: resultCount)
+        self.constructorIO.tracking.trackSearchResultsLoaded(searchTerm: "a search term", resultCount: resultCount)
     }
 }


### PR DESCRIPTION
- [x] Changed data pattern from "CIO_XXX_TrackData" to "CIOTrack_XXX_Data" so that it is easier to find tracking code end to end using find in files
- [x] Fixed filenames in a few comments
- [x] Changed `CIOTracking.trackResultsLoaded` to `CIOTracking.trackSearchResultsLoaded` for consistency