### PR TITLE
Changed TaskResponse properties scope to public

### DIFF
--- a/AutocompleteClient/FW/API/Data/TaskResponse.swift
+++ b/AutocompleteClient/FW/API/Data/TaskResponse.swift
@@ -13,8 +13,8 @@ import UIKit
  that has no data and no error
 */
 public class TaskResponse<T, E> {
-    let data: T?
-    let error: E?
+    public let data: T?
+    public let error: E?
 
     init(data: T) {
         self.data = data

--- a/AutocompleteClient/FW/Logic/Track/HasSectionName.swift
+++ b/AutocompleteClient/FW/Logic/Track/HasSectionName.swift
@@ -1,9 +1,9 @@
 //
 //  HasSectionName.swift
-//  AutocompleteClient
+//  Constructor.io
 //
-//  Created by Nikola Markovic on 6/25/18.
-//  Copyright © 2018 xd. All rights reserved.
+//  Copyright © Constructor.io. All rights reserved.
+//  http://constructor.io/
 //
 
 import Foundation


### PR DESCRIPTION
- TaskResponse properties should be public so they're accessible from outside the framework.
- Fixed HasSectionName file header.