### PR TITLE
[CSL 6] Handle Conversion Types with v2

### DIFF
--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -143,6 +143,7 @@ struct Constants {
         static let dateTime = "_dt"
         static let defaultItemSectionName = "Products"
         static let orderID = "order_id"
+        static let defaultConversionType = "add_to_cart"
     }
 
     struct TrackSessionStart {
@@ -186,7 +187,7 @@ struct Constants {
     }
 
     struct TrackConversion {
-        static let format = "%@/autocomplete/%@/conversion"
+        static let format = "%@/v2/behavioral_action/conversion"
     }
 
     struct TrackPurchase {

--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -144,6 +144,7 @@ struct Constants {
         static let defaultItemSectionName = "Products"
         static let orderID = "order_id"
         static let defaultConversionType = "add_to_cart"
+        static let conversionType = "type"
     }
 
     struct TrackSessionStart {

--- a/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
@@ -63,7 +63,7 @@ struct QueryItemCollection {
         let flattenedArray = self.queryItems.values.reduce([]) { res, next -> [URLQueryItem] in
             return res + next.reduce([], { res, next in return res + [next] })
         }
-        var dict: [String: Any] = [:]
+        var dict: [String: Any] = ["beacon": true]
         flattenedArray.forEach { item in
             if item.value != nil {
                 dict[item.name] = item.value

--- a/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
@@ -63,7 +63,7 @@ struct QueryItemCollection {
         let flattenedArray = self.queryItems.values.reduce([]) { res, next -> [URLQueryItem] in
             return res + next.reduce([], { res, next in return res + [next] })
         }
-        var dict: [String: Any] = ["beacon": true]
+        var dict: [String: Any] = [:]
         flattenedArray.forEach { item in
             if item.value != nil {
                 dict[item.name] = item.value

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -54,6 +54,11 @@ extension RequestBuilder {
         guard let sectionName = autocompleteSection else { return }
         queryItems.add(URLQueryItem(name: Constants.Track.autocompleteSection, value: sectionName))
     }
+    
+    func set(type: String?) {
+        guard let conversionType = type else { return }
+        queryItems.add(URLQueryItem(name: Constants.Track.conversionType, value: conversionType))
+    }
 
     func set(searchSection: String) {
         queryItems.add(URLQueryItem(name: Constants.SearchQuery.section, value: searchSection))

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -54,7 +54,7 @@ extension RequestBuilder {
         guard let sectionName = autocompleteSection else { return }
         queryItems.add(URLQueryItem(name: Constants.Track.autocompleteSection, value: sectionName))
     }
-    
+
     func set(type: String?) {
         guard let conversionType = type else { return }
         queryItems.add(URLQueryItem(name: Constants.Track.conversionType, value: conversionType))

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -16,6 +16,7 @@ struct CIOTrackConversionData: CIORequestData {
     let searchTerm: String
     let itemName: String
     let customerID: String
+    let variationID: String?
     var sectionName: String?
     let revenue: Double?
     let conversionType: String?
@@ -24,10 +25,11 @@ struct CIOTrackConversionData: CIORequestData {
         return String(format: Constants.TrackConversion.format, baseURL)
     }
 
-    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil) {
+    init(searchTerm: String, itemName: String, customerID: String, variationID: String? = nil, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil) {
         self.searchTerm = searchTerm
         self.itemName = itemName
         self.customerID = customerID
+        self.variationID = variationID
         self.sectionName = sectionName
         self.revenue = revenue
         self.conversionType = conversionType
@@ -38,16 +40,16 @@ struct CIOTrackConversionData: CIORequestData {
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
-        requestBuilder.set(name: self.itemName)
-        requestBuilder.set(customerID: self.customerID)
+        requestBuilder.set(autocompleteSection: self.sectionName)
     }
 
     func httpBody(baseParams: [String: Any]) -> Data? {
         var dict = [
             "search_term": self.searchTerm,
             "item_id": self.customerID,
+            "item_name": self.itemName,
         ] as [String: Any]
-
+        
         if self.revenue != nil {
             dict["revenue"] = NSString(format: "%.2f", self.revenue!)
         }
@@ -61,10 +63,6 @@ struct CIOTrackConversionData: CIORequestData {
         }
 
         dict.merge(baseParams) { current, _ in current }
-
-        // Remove name and customer id from dict as having them in the POST body throws an error
-        dict.removeValue(forKey: "name")
-        dict.removeValue(forKey: "customer_id")
 
         return try? JSONSerialization.data(withJSONObject: dict)
     }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -45,9 +45,9 @@ struct CIOTrackConversionData: CIORequestData {
         var dict = [
             "search_term": self.searchTerm,
             "item_id": self.customerID,
-            "item_name": self.itemName,
+            "item_name": self.itemName
         ] as [String: Any]
-        
+
         if self.revenue != nil {
             dict["revenue"] = NSString(format: "%.2f", self.revenue!)
         }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -43,6 +43,7 @@ struct CIOTrackConversionData: CIORequestData {
         requestBuilder.set(autocompleteSection: self.sectionName)
         requestBuilder.set(revenue: self.revenue)
         requestBuilder.set(type: self.conversionType)
+        requestBuilder.set(searchTerm: self.searchTerm)
     }
     
     func httpBody(baseParams: [String: Any]) -> Data? {
@@ -65,9 +66,10 @@ struct CIOTrackConversionData: CIORequestData {
 
         dict.merge(baseParams) { current, _ in current }
         
-        // Remove name and customer from dict as having them in the POST body throws an error
+        // Remove name, term, and customer from dict as having them in the POST body throws an error
         dict.removeValue(forKey: "name")
         dict.removeValue(forKey: "customer_id")
+        dict.removeValue(forKey: "term")
 
         return try? JSONSerialization.data(withJSONObject: dict)
     }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -16,7 +16,6 @@ struct CIOTrackConversionData: CIORequestData {
     let searchTerm: String
     let itemName: String
     let customerID: String
-    let variationID: String?
     var sectionName: String?
     let revenue: Double?
     let conversionType: String?
@@ -25,11 +24,10 @@ struct CIOTrackConversionData: CIORequestData {
         return String(format: Constants.TrackConversion.format, baseURL)
     }
 
-    init(searchTerm: String, itemName: String, customerID: String, variationID: String? = nil, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil) {
+    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil) {
         self.searchTerm = searchTerm
         self.itemName = itemName
         self.customerID = customerID
-        self.variationID = variationID
         self.sectionName = sectionName
         self.revenue = revenue
         self.conversionType = conversionType

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -18,17 +18,23 @@ struct CIOTrackConversionData: CIORequestData {
     let customerID: String
     var sectionName: String?
     let revenue: Double?
-
+    let conversionType: String?
+    
     func url(with baseURL: String) -> String {
-        return String(format: Constants.TrackConversion.format, baseURL, self.searchTerm.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!)
+        return String(format: Constants.TrackConversion.format, baseURL)
     }
 
-    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, revenue: Double? = nil) {
+    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil) {
         self.searchTerm = searchTerm
         self.itemName = itemName
         self.customerID = customerID
         self.sectionName = sectionName
         self.revenue = revenue
+        self.conversionType = conversionType
+    }
+    
+    func httpMethod() -> String {
+        return "POST"
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -36,5 +42,25 @@ struct CIOTrackConversionData: CIORequestData {
         requestBuilder.set(customerID: self.customerID)
         requestBuilder.set(autocompleteSection: self.sectionName)
         requestBuilder.set(revenue: self.revenue)
+    }
+    
+    func httpBody(baseParams: [String: Any]) -> Data? {
+        var dict = [
+            "type": self.conversionType!,
+            "search_term": self.searchTerm,
+            "item_id": self.itemName,
+        ] as [String: Any]
+
+        if self.revenue != nil {
+            dict["revenue"] = self.revenue
+        }
+        
+        if self.sectionName != nil {
+            dict["section"] = self.sectionName
+        }
+
+        dict.merge(baseParams) { current, _ in current }
+
+        return try? JSONSerialization.data(withJSONObject: dict)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -19,7 +19,7 @@ struct CIOTrackConversionData: CIORequestData {
     var sectionName: String?
     let revenue: Double?
     let conversionType: String?
-    
+
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackConversion.format, baseURL)
     }
@@ -32,7 +32,7 @@ struct CIOTrackConversionData: CIORequestData {
         self.revenue = revenue
         self.conversionType = conversionType
     }
-    
+
     func httpMethod() -> String {
         return "POST"
     }
@@ -40,12 +40,8 @@ struct CIOTrackConversionData: CIORequestData {
     func decorateRequest(requestBuilder: RequestBuilder) {
         requestBuilder.set(name: self.itemName)
         requestBuilder.set(customerID: self.customerID)
-        requestBuilder.set(autocompleteSection: self.sectionName)
-        requestBuilder.set(revenue: self.revenue)
-        requestBuilder.set(type: self.conversionType)
-        requestBuilder.set(searchTerm: self.searchTerm)
     }
-    
+
     func httpBody(baseParams: [String: Any]) -> Data? {
         var dict = [
             "search_term": self.searchTerm,
@@ -55,21 +51,20 @@ struct CIOTrackConversionData: CIORequestData {
         if self.revenue != nil {
             dict["revenue"] = NSString(format: "%.2f", self.revenue!)
         }
-        
+
         if self.sectionName != nil {
             dict["section"] = self.sectionName
         }
-        
-        if self.sectionName != nil {
+
+        if self.conversionType != nil {
             dict["type"] = self.conversionType
         }
 
         dict.merge(baseParams) { current, _ in current }
-        
+
         // Remove name, term, and customer from dict as having them in the POST body throws an error
         dict.removeValue(forKey: "name")
         dict.removeValue(forKey: "customer_id")
-        dict.removeValue(forKey: "term")
 
         return try? JSONSerialization.data(withJSONObject: dict)
     }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -62,7 +62,7 @@ struct CIOTrackConversionData: CIORequestData {
 
         dict.merge(baseParams) { current, _ in current }
 
-        // Remove name, term, and customer from dict as having them in the POST body throws an error
+        // Remove name and customer id from dict as having them in the POST body throws an error
         dict.removeValue(forKey: "name")
         dict.removeValue(forKey: "customer_id")
 

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -42,24 +42,32 @@ struct CIOTrackConversionData: CIORequestData {
         requestBuilder.set(customerID: self.customerID)
         requestBuilder.set(autocompleteSection: self.sectionName)
         requestBuilder.set(revenue: self.revenue)
+        requestBuilder.set(type: self.conversionType)
     }
     
     func httpBody(baseParams: [String: Any]) -> Data? {
         var dict = [
-            "type": self.conversionType!,
             "search_term": self.searchTerm,
-            "item_id": self.itemName,
+            "item_id": self.customerID,
         ] as [String: Any]
 
         if self.revenue != nil {
-            dict["revenue"] = self.revenue
+            dict["revenue"] = NSString(format: "%.2f", self.revenue!)
         }
         
         if self.sectionName != nil {
             dict["section"] = self.sectionName
         }
+        
+        if self.sectionName != nil {
+            dict["type"] = self.conversionType
+        }
 
         dict.merge(baseParams) { current, _ in current }
+        
+        // Remove name and customer from dict as having them in the POST body throws an error
+        dict.removeValue(forKey: "name")
+        dict.removeValue(forKey: "customer_id")
 
         return try? JSONSerialization.data(withJSONObject: dict)
     }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
@@ -46,7 +46,7 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
             "pod_id": self.podID,
             "url": self.url
         ] as [String: Any]
-    
+
         if self.numResultsViewed != nil {
             dict["num_results_viewed"] = self.numResultsViewed
         }

--- a/AutocompleteClient/FW/Logic/Result/CIOResult.swift
+++ b/AutocompleteClient/FW/Logic/Result/CIOResult.swift
@@ -26,7 +26,7 @@ public class CIOResult: NSObject {
         let variationsObj = json["variations"] as? [JSONObject]
 
         let variations: [CIOResult] = variationsObj?.compactMap { obj in return CIOResult(json: obj) } ?? []
-    
+
         let strategyData = json["strategy"] as? JSONObject ?? [String: Any]()
 
         let strategy: CIORecommendationsStrategy = CIORecommendationsStrategy(json: strategyData)!

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -236,10 +236,11 @@ public class ConstructorIO: CIOSessionManagerDelegate {
     ///   - searchTerm: Search term that the user searched for. If nil is passed, 'TERM_UNKNOWN' will be sent to the server.
     ///   - sectionName The name of the autocomplete section the term came from
     ///   - completionHandler: The callback to execute on completion.
-    public func trackConversion(itemName: String, customerID: String, revenue: Double?, searchTerm: String? = nil, sectionName: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackConversion(itemName: String, customerID: String, revenue: Double?, searchTerm: String? = nil, sectionName: String? = nil, conversionType: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
+        let type = conversionType ?? Constants.Track.defaultConversionType
         let term = searchTerm == nil ? "TERM_UNKNOWN" : (searchTerm!.isEmpty) ? "TERM_UNKNOWN" : searchTerm
-        let data = CIOTrackConversionData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, revenue: revenue)
+        let data = CIOTrackConversionData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, revenue: revenue, conversionType: type)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
@@ -16,6 +16,8 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     fileprivate let itemName = "some item name"
     fileprivate let customerID = "custIDq3éû qd"
     fileprivate let sectionName = "some section name@"
+    fileprivate let conversionType = "like"
+    fileprivate let revenue = 12.45
 
     fileprivate var encodedSearchTerm: String = ""
     fileprivate var encodedItemName: String = ""
@@ -63,44 +65,64 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         builder.build(trackData: tracker)
         let request = builder.getRequest()
         let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
-        XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
+        XCTAssertEqual(payload?["section"] as? String, sectionName)
+    }
+
+    func testTrackConversionBuilder_WithConversionType() {
+        let tracker = CIOTrackConversionData(searchTerm: self.searchTerm, itemName: self.itemName, customerID: self.customerID, conversionType: self.conversionType)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
+        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
+        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
+        XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
+        XCTAssertEqual(payload?["type"] as? String, conversionType)
     }
 
     func testTrackConversionBuilder_WithRevenue() {
-        let tracker = CIOTrackConversionData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, revenue: 9999)
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, revenue: revenue)
         builder.build(trackData: tracker)
         let request = builder.getRequest()
         let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
-        XCTAssertTrue(url.contains("revenue=9999.00"), "URL should contain the revenue parameter.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
+        XCTAssertEqual(payload?["revenue"] as? String, String(revenue))
     }
 
-    func testTrackConversionBuilder_WithSectionNameAndRevenue() {
-        let tracker = CIOTrackConversionData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, sectionName: sectionName, revenue: 12.345)
+    func testTrackConversionBuilder_WithSectionNameRevenueAndType() {
+        let tracker = CIOTrackConversionData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, sectionName: sectionName, revenue: revenue, conversionType: conversionType)
         builder.build(trackData: tracker)
         let request = builder.getRequest()
         let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
-        XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
-        XCTAssertTrue(url.contains("revenue=12.35"), "URL should contain the revenue parameter.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
+        XCTAssertEqual(payload?["revenue"] as? String, String(revenue))
+        XCTAssertEqual(payload?["type"] as? String, conversionType)
+        XCTAssertEqual(payload?["section"] as? String, sectionName)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
@@ -40,13 +40,15 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         builder.build(trackData: tracker)
         let request = builder.getRequest()
         let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
-        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
-        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 
     func testTrackConversionBuilder_WithCustomBaseURL() {
@@ -56,8 +58,12 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         builder.build(trackData: tracker)
         let request = builder.getRequest()
         let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
 
         XCTAssertTrue(url.hasPrefix(customBaseURL))
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 
     func testTrackConversionBuilder_WithSectionName() {
@@ -69,11 +75,13 @@ class TrackConversionRequestBuilderTests: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
-        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
-        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the section.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
         XCTAssertEqual(payload?["section"] as? String, sectionName)
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 
     func testTrackConversionBuilder_WithConversionType() {
@@ -85,11 +93,12 @@ class TrackConversionRequestBuilderTests: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
-        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
-        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
         XCTAssertEqual(payload?["type"] as? String, conversionType)
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 
     func testTrackConversionBuilder_WithRevenue() {
@@ -101,11 +110,12 @@ class TrackConversionRequestBuilderTests: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
-        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
-        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
         XCTAssertEqual(payload?["revenue"] as? String, String(revenue))
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 
     func testTrackConversionBuilder_WithSectionNameRevenueAndType() {
@@ -114,15 +124,16 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let request = builder.getRequest()
         let url = request.url!.absoluteString
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
-
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
-        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
-        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the section.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
         XCTAssertEqual(payload?["revenue"] as? String, String(revenue))
         XCTAssertEqual(payload?["type"] as? String, conversionType)
         XCTAssertEqual(payload?["section"] as? String, sectionName)
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
@@ -39,8 +39,8 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let request = builder.getRequest()
         let url = request.url!.absoluteString
 
-        XCTAssertEqual(request.httpMethod, "GET")
-        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
@@ -64,8 +64,8 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let request = builder.getRequest()
         let url = request.url!.absoluteString
 
-        XCTAssertEqual(request.httpMethod, "GET")
-        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
@@ -79,8 +79,8 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let request = builder.getRequest()
         let url = request.url!.absoluteString
 
-        XCTAssertEqual(request.httpMethod, "GET")
-        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("revenue=9999.00"), "URL should contain the revenue parameter.")
@@ -94,8 +94,8 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         let request = builder.getRequest()
         let url = request.url!.absoluteString
 
-        XCTAssertEqual(request.httpMethod, "GET")
-        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/conversion?"))
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item id.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
         XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")

--- a/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
@@ -78,7 +78,7 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
         XCTAssertEqual(payload?["revenue"] as? Double, revenue)
     }
-    
+
     func testTrackPurchaseBuilder_WithOrderID() {
         let tracker = CIOTrackPurchaseData(customerIDs: self.customerIDs, sectionName: self.sectionName, orderID: self.orderID)
         builder.build(trackData: tracker)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -134,7 +134,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testConversion() {
         let expectation = XCTestExpectation(description: "Tracking 204")
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName, conversionType: conversionType, completionHandler: { response in

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -134,20 +134,20 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-
-    func testPurchase() {
+    
+    func testConversion() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackPurchase(customerIDs: customerIDs, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
+        self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName, conversionType: conversionType, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
         })
         self.wait(for: expectation)
     }
-    
-    func testConversion() {
+
+    func testPurchase() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName, conversionType: conversionType, completionHandler: { response in
+        self.constructor.trackPurchase(customerIDs: customerIDs, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -31,6 +31,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
     fileprivate let numResultsPerPage = 5
     fileprivate let numResultsViewed = 5
     fileprivate let resultPage = 1
+    fileprivate let conversionType = "add_to_cart"
 
     var constructor: ConstructorIO!
 
@@ -134,19 +135,19 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testConversion() {
+    func testPurchase() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName, completionHandler: { response in
+        self.constructor.trackPurchase(customerIDs: customerIDs, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
         })
         self.wait(for: expectation)
     }
-
-    func testPurchase() {
+    
+    func testConversion() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackPurchase(customerIDs: customerIDs, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
+        self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName, conversionType: conversionType, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
@@ -30,7 +30,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -40,7 +40,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=TERM_UNKNOWN&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: nil, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -50,7 +50,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=TERM_UNKNOWN&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: "", sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -62,7 +62,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "Search Suggestions"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Search%20Suggestions&term=corn&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName)
         self.wait(for: builder.expectation)
     }
@@ -74,7 +74,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let conversionType = "like"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a type.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=\(conversionType)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, conversionType: conversionType)
         self.wait(for: builder.expectation)
     }
@@ -86,7 +86,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "section321"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=\(sectionName)&term=corn&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
         let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultItemSectionName: sectionName)
         let constructor = TestConstants.testConstructor(config)
         constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm)
@@ -99,7 +99,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), http(400))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), http(400))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .badRequest, "If tracking call returns status code 400, the error should be delegated to the completion handler")
@@ -115,7 +115,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), http(500))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), http(500))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .internalServerError, "If tracking call returns status code 500, the error should be delegated to the completion handler")
@@ -131,7 +131,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), noConnectivity())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), noConnectivity())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, CIOError.noConnection, "If tracking call returns no connectivity, the error should be delegated to the completion handler")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
@@ -30,7 +30,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -40,7 +40,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=TERM_UNKNOWN&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: nil, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -50,7 +50,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=TERM_UNKNOWN&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: "", sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -62,7 +62,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "Search Suggestions"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Search%20Suggestions&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Search%20Suggestions&term=corn&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName)
         self.wait(for: builder.expectation)
     }
@@ -74,7 +74,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let conversionType = "like"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a type.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=like"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=\(conversionType)"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, conversionType: conversionType)
         self.wait(for: builder.expectation)
     }
@@ -86,7 +86,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "section321"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=\(sectionName)&type=add_to_cart"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=\(sectionName)&term=corn&type=add_to_cart"), builder.create())
         let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultItemSectionName: sectionName)
         let constructor = TestConstants.testConstructor(config)
         constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm)
@@ -99,7 +99,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), http(400))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), http(400))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .badRequest, "If tracking call returns status code 400, the error should be delegated to the completion handler")
@@ -115,7 +115,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), http(500))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), http(500))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .internalServerError, "If tracking call returns status code 500, the error should be delegated to the completion handler")
@@ -131,7 +131,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), noConnectivity())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&term=corn&type=add_to_cart"), noConnectivity())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, CIOError.noConnection, "If tracking call returns no connectivity, the error should be delegated to the completion handler")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
@@ -66,7 +66,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName)
         self.wait(for: builder.expectation)
     }
-    
+
     func testTrackConversion_WithType() {
         let searchTerm = "corn"
         let itemName = "green-giant-corn-can-12oz"

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
@@ -30,7 +30,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -40,7 +40,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: nil, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -50,7 +50,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: "", sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -62,7 +62,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "Search Suggestions"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Search%20Suggestions"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName)
         self.wait(for: builder.expectation)
     }
@@ -74,7 +74,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let conversionType = "like"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a type.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, conversionType: conversionType)
         self.wait(for: builder.expectation)
     }
@@ -86,7 +86,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "section321"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=section321"), builder.create())
         let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultItemSectionName: sectionName)
         let constructor = TestConstants.testConstructor(config)
         constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm)
@@ -99,7 +99,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), http(400))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), http(400))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .badRequest, "If tracking call returns status code 400, the error should be delegated to the completion handler")
@@ -115,7 +115,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), http(500))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), http(500))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .internalServerError, "If tracking call returns status code 500, the error should be delegated to the completion handler")
@@ -131,7 +131,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)"), noConnectivity())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), noConnectivity())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, CIOError.noConnection, "If tracking call returns no connectivity, the error should be delegated to the completion handler")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
@@ -30,7 +30,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -40,7 +40,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/autocomplete/TERM_UNKNOWN/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: nil, sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -50,7 +50,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let customerID = "customerID123"
         let revenue: Double = 1
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a default section name and default term.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/autocomplete/TERM_UNKNOWN/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: "", sectionName: nil)
         self.wait(for: builder.expectation)
     }
@@ -62,8 +62,20 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "Search Suggestions"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Search%20Suggestions"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Search%20Suggestions&type=add_to_cart"), builder.create())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName)
+        self.wait(for: builder.expectation)
+    }
+    
+    func testTrackConversion_WithType() {
+        let searchTerm = "corn"
+        let itemName = "green-giant-corn-can-12oz"
+        let customerID = "customerID123"
+        let revenue: Double = 1
+        let conversionType = "like"
+        let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a type.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=like"), builder.create())
+        self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, conversionType: conversionType)
         self.wait(for: builder.expectation)
     }
 
@@ -74,7 +86,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let revenue: Double = 1
         let sectionName = "section321"
         let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=\(sectionName)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=\(sectionName)&type=add_to_cart"), builder.create())
         let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultItemSectionName: sectionName)
         let constructor = TestConstants.testConstructor(config)
         constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm)
@@ -87,7 +99,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products"), http(400))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), http(400))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .badRequest, "If tracking call returns status code 400, the error should be delegated to the completion handler")
@@ -103,7 +115,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products"), http(500))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), http(500))
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, .internalServerError, "If tracking call returns status code 500, the error should be delegated to the completion handler")
@@ -119,7 +131,7 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         let itemName = "green-giant-corn-can-12oz"
         let customerID = "customerID123"
         let revenue: Double = 1
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products"), noConnectivity())
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&revenue=1.00&s=\(kRegexSession)&section=Products&type=add_to_cart"), noConnectivity())
         self.constructor.trackConversion(itemName: itemName, customerID: customerID, revenue: revenue, searchTerm: searchTerm, sectionName: nil, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError, CIOError.noConnection, "If tracking call returns no connectivity, the error should be delegated to the completion handler")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
@@ -33,7 +33,7 @@ class ConstructorIOTrackRecommendationResultsViewTests: XCTestCase {
         self.constructor.trackRecommendationResultsView(podID: podID)
         self.wait(for: builder.expectation)
     }
-    
+
     func testTrackRecommendationResultsView_WithOptionalParams() {
         let podID = "item_page_1"
         let numResultsViewed = 5

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ constructorIO.trackRecommendationResultClick(podID: "pdp_best_sellers", strategy
 
 ```swift
 // Track when an item converts (a.k.a. is added to cart) regardless of the user journey that led to adding to cart
-constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", revenue: 12.99, searchTerm: "tooth")
+constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", revenue: 12.99, searchTerm: "tooth", conversionType: "add_to_cart")
 
 // Track when items are purchased
 constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")


### PR DESCRIPTION
- Pass type in request body
- v2 endpoint expects revenue as String
  - Taking it in as a double to conform with other method and converting it into string
- Added and updated tests
- Update readme
- Add custom_type and display_name in later PR