### PR TITLE
Update Deployment Target in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "ConstructorIO",
     
     platforms: [
-        .iOS(.v8)
+        .iOS(.v9)
     ],
     products: [
         .library(name: "ConstructorAutocomplete", targets: ["ConstructorAutocomplete"])


### PR DESCRIPTION
It was observed that when pulling in the Constructor SDK via SwiftPM, the deployment target being set to 8.0 was causing Xcode to emit a warning. (See below screenshot) 

This PR bumps the deployment target from `.v8` to `.v9`. 

<img width="642" alt="Screen Shot 2021-05-12 at 9 01 29 AM" src="https://user-images.githubusercontent.com/26095410/117986718-ddaa4a80-b307-11eb-9bb2-049d0b156890.png">
