### PR TITLE
[CSL 395] Add Filtering to Autocomplete Requests

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/CIOAutocompleteQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOAutocompleteQuery.swift
@@ -26,7 +26,7 @@ public struct CIOAutocompleteQuery: CIORequestData {
      The section to return results from
      */
     let numResultsForSection: [String: Int]?
-    
+
     /**
      The filters used to refine results
      */

--- a/AutocompleteClient/FW/Logic/Request/CIOAutocompleteQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOAutocompleteQuery.swift
@@ -26,6 +26,11 @@ public struct CIOAutocompleteQuery: CIORequestData {
      The section to return results from
      */
     let numResultsForSection: [String: Int]?
+    
+    /**
+     The filters used to refine results
+     */
+    let filters: CIOQueryFilters?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.AutocompleteQuery.format, baseURL, query)
@@ -38,20 +43,24 @@ public struct CIOAutocompleteQuery: CIORequestData {
         - query: User typed query to return results for
         - numResults: The number of results to return
         - numresultsForSection: The section to return results from
+        - filters: The filters used to refine results
      
      ### Usage Example: ###
      ```
      let autocompleteQuery = CIOAutocompleteQuery(query: "apple", numResults: 5, numResultsForSection: ["Products": 6, "Search Suggestions": 8])
      ```
      */
-    public init(query: String, numResults: Int? = nil, numResultsForSection: [String: Int]? = nil) {
+    public init(query: String, filters: CIOQueryFilters? = nil, numResults: Int? = nil, numResultsForSection: [String: Int]? = nil) {
         self.query = query.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.numResults = numResults
         self.numResultsForSection = numResultsForSection
+        self.filters = filters
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
         requestBuilder.set(numResults: self.numResults)
         requestBuilder.set(numResultsForSection: self.numResultsForSection)
+        requestBuilder.set(groupFilter: self.filters?.groupFilter)
+        requestBuilder.set(facetFilters: self.filters?.facetFilters)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/AutocompleteQueryRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/AutocompleteQueryRequestBuilderTests.swift
@@ -98,4 +98,36 @@ class AutocompleteQueryRequestBuilderTests: XCTestCase {
         let url = request.url!.absoluteString
         XCTAssertTrue(url.hasPrefix("\(customBaseURL)/autocomplete/\(endodedQuery)?"))
     }
+
+    func testAutocompleteQueryBuilder_WithAGroupFilter() {
+        let facetFilters = [
+            (key: "Nutrition", value: "Organic")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
+        let query = CIOAutocompleteQuery(query: self.query, filters: queryFilters, numResults: 20)
+        builder.build(trackData: query)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(endodedQuery)?"))
+        print(url)
+        XCTAssertTrue(url.contains("filters%5BNutrition%5D=Organic"), "URL should contain the Nutrition facet filter.")
+        XCTAssertTrue(url.contains("num_results=20"), "URL should contain the num_results URL parameter.")
+        XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain api key.")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testAutocompleteQueryBuilder_WithAFacetFilter() {
+        let queryFilters = CIOQueryFilters(groupFilter: "101", facetFilters: nil)
+        let query = CIOAutocompleteQuery(query: self.query, filters: queryFilters, numResults: 20)
+        builder.build(trackData: query)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(endodedQuery)?"))
+        XCTAssertTrue(url.contains("filters%5Bgroup_id%5D=101"), "URL should contain the group filter.")
+        XCTAssertTrue(url.contains("num_results=20"), "URL should contain the num_results URL parameter.")
+        XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain api key.")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOAutocompleteTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOAutocompleteTests.swift
@@ -25,7 +25,7 @@ class ConstructorIOAutocompleteTests: XCTestCase {
         let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
         stub(regex("https://ac.cnstrc.com/autocomplete/a%20term?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), builder.create())
 
-        self.constructor.autocomplete(forQuery: query) { (_) in }
+        self.constructor.autocomplete(forQuery: query) { _ in }
         self.wait(for: builder.expectation)
     }
 
@@ -36,7 +36,7 @@ class ConstructorIOAutocompleteTests: XCTestCase {
 
         stub(regex("https://ac.cnstrc.com/autocomplete/a%20term?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), noConnectivity())
 
-        self.constructor.autocomplete(forQuery: query) { (response) in
+        self.constructor.autocomplete(forQuery: query) { response in
             if let error = response.error as? CIOError {
                 XCTAssertEqual(error, CIOError.noConnection, "Returned error from network client should be type CIOError.noConnection.")
                 expectation.fulfill()
@@ -52,7 +52,7 @@ class ConstructorIOAutocompleteTests: XCTestCase {
 
         stub(regex("https://ac.cnstrc.com/autocomplete/a%20term?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(400))
 
-        self.constructor.autocomplete(forQuery: query) { (response) in
+        self.constructor.autocomplete(forQuery: query) { response in
             if let error = response.error as? CIOError {
                 XCTAssertEqual(error, CIOError.badRequest, "Returned error from network client should be type CIOError.badRequest.")
                 expectation.fulfill()
@@ -68,7 +68,7 @@ class ConstructorIOAutocompleteTests: XCTestCase {
 
         stub(regex("https://ac.cnstrc.com/autocomplete/a%20term?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(500))
 
-        self.constructor.autocomplete(forQuery: query) { (response) in
+        self.constructor.autocomplete(forQuery: query) { response in
             if let error = response.error as? CIOError {
                 XCTAssertEqual(error, CIOError.internalServerError, "Returned error from network client should be type CIOError, internalServerError.")
                 expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -87,7 +87,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testSearchResultClick() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        let request = self.constructor.trackSearchResultClick(itemName: itemName, customerID: customerID, searchTerm: searchTerm, sectionName: sectionName, resultID: nil, completionHandler: { response in
+        self.constructor.trackSearchResultClick(itemName: itemName, customerID: customerID, searchTerm: searchTerm, sectionName: sectionName, resultID: nil, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -97,7 +97,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testBrowseResultsLoaded() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        var request = self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: nil, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: nil, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -156,7 +156,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
     }
 
     func testRecommendations() {
-        let expectation = XCTestExpectation(description: "Request 200")
+        let expectation = XCTestExpectation(description: "Request 204")
         let query = CIORecommendationsQuery(podID: podID, itemID: customerID, section: sectionName)
         self.constructor.recommendations(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
@@ -166,6 +166,84 @@ class ConstructorIOIntegrationTests: XCTestCase {
             XCTAssertEqual(responseData.pod.id, self.podID, "Pod ID should match the JSON response")
             XCTAssertEqual(responseData.totalNumResults, 5, "Recommendations count should match the JSON response")
 
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testAutocomplete() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let query = CIOAutocompleteQuery(query: "a", filters: nil, numResults: 20)
+        self.constructor.autocomplete(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testAutocomplete_WithFilters() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let facetFilters = [
+            (key: "Brand", value: "A&W")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
+        let query = CIOAutocompleteQuery(query: "a", filters: queryFilters, numResults: 20)
+        self.constructor.autocomplete(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testSearch() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let query = CIOSearchQuery(query: "a", filters: nil)
+        self.constructor.search(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testSearch_WithFilters() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let facetFilters = [
+            (key: "Brand", value: "A&W")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: "101", facetFilters: facetFilters)
+        let query = CIOSearchQuery(query: "a", filters: queryFilters)
+        self.constructor.search(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testBrowse() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "431")
+        self.constructor.browse(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testBrowse_WithFilters() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let facetFilters = [
+            (key: "Brand", value: "A&W")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: "101", facetFilters: facetFilters)
+        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "431", filters: queryFilters)
+        self.constructor.browse(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
             expectation.fulfill()
         })
         self.wait(for: expectation)


### PR DESCRIPTION
#### Updates:
* Add support for filtering in autocomplete requests
* Add integration tests for Browse, Search and Autocomplete
* Fix some lint issues
* Autocomplete requests only accepts 1 filter at the moment and returns an error if more than 1 is supplied:
    * `Error Code 400: Bad Request - Your request is invalid.` which doesn't seem very helpful? 🤔 
    * The error that comes back from the server is `Only single filters are supported in autocomplete, but you seem to have provided more than one.`, but it doesn't seem to show up in the response object in Swift. It looks like all that information is being stripped away, but I don't understand Swift enough to figure out where/how that's happening
    * I guess they can reference the API doc to figure out why.. but that kind of sucks to need to do that...