### PR TITLE
[CSL 573] Pod Spec Lint Fixes

### DIFF
--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
+		BF45F3E626E187640069F13E /* NoSessionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EC29B321762BD700DCFA07 /* NoSessionLoader.swift */; };
 		BF67BD3025E71F6E0039D479 /* CIORecommendationsStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF67BD2F25E71F6E0039D479 /* CIORecommendationsStrategy.swift */; };
 		BFC9502625D206C400118D4C /* RecommendationsQueryRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC9502425D206C400118D4C /* RecommendationsQueryRequestBuilderTests.swift */; };
 		BFC9502C25D48CE400118D4C /* AbstractRecommendationsResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC9502B25D48CE400118D4C /* AbstractRecommendationsResponseParser.swift */; };
@@ -2196,6 +2197,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF45F3E626E187640069F13E /* NoSessionLoader.swift in Sources */,
 				F64F46FD1F59D72C0094C697 /* XCTest+TimeoutFail.swift in Sources */,
 				F63374B11F5AA20500E481E7 /* ExpectationHandler.swift in Sources */,
 				F64F46FE1F59D7330094C697 /* TestConstants.swift in Sources */,

--- a/AutocompleteClient/FW/API/Parser/Autocomplete/ResponseParserDelegate.swift
+++ b/AutocompleteClient/FW/API/Parser/Autocomplete/ResponseParserDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol ResponseParserDelegate: class {
+protocol ResponseParserDelegate: AnyObject {
     func shouldParseResult(result: CIOResult, inGroup group: CIOGroup?) -> Bool?
     func maximumGroupsShownPerResult(result: CIOResult, at index: Int) -> Int
 }

--- a/AutocompleteClient/FW/Logic/Session/CIOSessionManagerDelegate.swift
+++ b/AutocompleteClient/FW/Logic/Session/CIOSessionManagerDelegate.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public protocol CIOSessionManagerDelegate: class {
+public protocol CIOSessionManagerDelegate: AnyObject {
     func sessionDidChange(from: Int, to: Int)
 }

--- a/AutocompleteClient/FW/Logic/Session/SessionManager.swift
+++ b/AutocompleteClient/FW/Logic/Session/SessionManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol SessionManager: class {
+public protocol SessionManager: AnyObject {
     var delegate: CIOSessionManagerDelegate? { get set }
 
     func getSessionWithIncrement() -> Int

--- a/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
+++ b/AutocompleteClient/FW/UI/Delegate/CIOAutocompleteDelegate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objc
-public protocol CIOAutocompleteDelegate: class {
+public protocol CIOAutocompleteDelegate: AnyObject {
 
     /**
      Called when CIOAutocompleteViewController's view is loaded (viewDidLoad).

--- a/AutocompleteClient/FW/UI/Error/CIOErrorView.swift
+++ b/AutocompleteClient/FW/UI/Error/CIOErrorView.swift
@@ -11,7 +11,7 @@ import UIKit
 /**
  Conform to this protocol if you want to use a custom error view.
  */
-public protocol CIOErrorView: class, NSObjectProtocol {
+public protocol CIOErrorView: NSObjectProtocol {
     /**
      Returns a UIView instance. If your UIView implements this protocol, simply return self.
 

--- a/AutocompleteClient/FW/UI/UICustomization/CIOAutocompleteUICustomization.swift
+++ b/AutocompleteClient/FW/UI/UICustomization/CIOAutocompleteUICustomization.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @objc
-public protocol CIOAutocompleteUICustomization: class {
+public protocol CIOAutocompleteUICustomization: AnyObject {
 
     /**
      Returns a custom cell nib to be used in the CIOAutocompleteViewController.

--- a/AutocompleteClient/FW/UI/ViewModel/AutocompleteViewModelDelegate.swift
+++ b/AutocompleteClient/FW/UI/ViewModel/AutocompleteViewModelDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol AutocompleteViewModelDelegate: class {
+public protocol AutocompleteViewModelDelegate: AnyObject {
     func viewModel(_ viewModel: AbstractAutocompleteViewModel, didIgnoreResult result: AutocompleteResult)
     func viewModel(_ viewModel: AbstractAutocompleteViewModel, didSetResult result: AutocompleteResult)
 }

--- a/ConstructorAutocomplete.podspec
+++ b/ConstructorAutocomplete.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
   spec.platform     = :ios, '8.0'
   spec.source_files = 'AutocompleteClient/**/*.swift'
   spec.framework    = 'UIKit'
-  spec.swift_versions = ['4.0', '4.1', '4.2']
+  spec.swift_versions = ['4.0', '4.1', '4.2', '5']
   spec.ios.resource_bundle 	  = { 'ConstructorAutocomplete' => ['AutocompleteClient/Resources/*.png', 'AutocompleteClient/**/*.xib'] }
 end

--- a/UserApplication/AppDelegate.swift
+++ b/UserApplication/AppDelegate.swift
@@ -142,7 +142,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CIOAutocompleteDelegate, 
     func autocompleteController(controller: CIOAutocompleteViewController, errorDidOccur error: Error) {
         
         if let err = error as? CIOError {
-            switch(err) {
+            switch(err.errorType) {
             case .missingApiKey:
                 print("Missing api key error")
             default:


### PR DESCRIPTION
### Updates:
* Add swift v5.0 to list of swift versions
* Fix lint warnings

### Side Notes:
* I ran the user application tests and made some small updates to the dependencies and minor change to a test
* One of the user application tests doesn't seem to work and I'm not sure why (or if it's something we need to care about 🤔 )

<img width="939" alt="Screen Shot 2021-09-02 at 3 20 07 PM" src="https://user-images.githubusercontent.com/7194266/131924752-83fafa4c-5b40-4bfc-a1ad-8ebf8657394a.png">
<img width="939" alt="Screen Shot 2021-09-02 at 3 20 07 PM" src="https://user-images.githubusercontent.com/7194266/131924776-01742595-917f-4a19-b3c7-c89695847e52.png">
