### PR TITLE
[CSL 1175] Encode plus sign in query params

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder.swift
@@ -87,6 +87,10 @@ class RequestBuilder {
 
         urlComponents.queryItems = self.trackData!.queryItems(baseItems: allQueryItems.all())
 
+        // Replace "+" with "%2B" in the query parameters
+        urlComponents.percentEncodedQuery = urlComponents.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
+
         let url = urlComponents.url!
         let httpBody = self.trackData!.httpBody(baseParams: allQueryItems.allAsDictionary())
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOAutocompleteTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOAutocompleteTests.swift
@@ -94,6 +94,21 @@ class ConstructorIOAutocompleteTests: XCTestCase {
         self.wait(for: expectation)
     }
 
+    func testAutocomplete_WithPlusSignInQueryParams_ShouldBeEncoded() {
+        let facetFilters = [
+            (key: "size", value: "6+"),
+            (key: "age", value: "10+")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
+        let query = CIOAutocompleteQuery(query: "potato", filters: queryFilters)
+
+        let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5Bage%5D=10%2B&filters%5Bsize%5D=6%2B&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), builder.create())
+
+        self.constructor.autocomplete(forQuery: query) { _ in }
+        self.wait(for: builder.expectation)
+    }
+
     func testAutocomplete_UsingAutocompleteQueryBuilder_WithValidRequest_ReturnsNonNilResponse() {
         let query = CIOAutocompleteQueryBuilder(query: "potato").build()
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
@@ -129,7 +129,22 @@ class ConstructorIOBrowseTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
-    func testBrowse_UsingSearchQueryBuilder_WithValidRequest_ReturnsNonNilResponse() {
+    func testBrowse_WithPlusSignInQueryParams_ShouldBeEncoded() {
+        let facetFilters = [
+            (key: "size", value: "6+"),
+            (key: "age", value: "10+")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
+        let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet", filters: queryFilters)
+
+        let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5Bage%5D=10%2B&filters%5Bsize%5D=6%2B&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.browse(forQuery: query) { _ in }
+        self.wait(for: builder.expectation)
+    }
+
+    func testBrowse_UsingBrowseQueryBuilder_WithValidRequest_ReturnsNonNilResponse() {
         let query = CIOBrowseQueryBuilder(filterName: "potato", filterValue: "russet").build()
 
         let builder = CIOBuilder(expectation: "Calling Search with valid parameters should return a non-nil response.", builder: http(200))
@@ -141,7 +156,7 @@ class ConstructorIOBrowseTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
-    func testBrowse_UsingSearchQueryBuilder_AttachesPageParams() {
+    func testBrowse_UsingBrowseQueryBuilder_AttachesPageParams() {
         let query = CIOBrowseQueryBuilder(filterName: "potato", filterValue: "russet")
             .setPage(5)
             .setPerPage(50)
@@ -156,7 +171,7 @@ class ConstructorIOBrowseTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
-    func testBrowse_UsingSearchQueryBuilder_AttachesSortOption() {
+    func testBrowse_UsingBrowseQueryBuilder_AttachesSortOption() {
         let sortOption = CIOSortOption(json: [
             "sort_by": "relevance",
             "sort_order": "descending",
@@ -175,7 +190,7 @@ class ConstructorIOBrowseTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
-    func testBrowse_UsingSearchQueryBuilder_AttachesFacetFilters() {
+    func testBrowse_UsingBrowseQueryBuilder_AttachesFacetFilters() {
         let facetFilters = [(key: "facetOne", value: "Organic"),
                             (key: "facetOne", value: "Natural"),
                             (key: "facetOne", value: "Whole-grain")]

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIORecommendationsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIORecommendationsTests.swift
@@ -153,6 +153,20 @@ class ConstructorIORecommendationsTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testRecommendations_WithPlusSignInQueryParams_ShouldBeEncoded() {
+        let facetFilters = [
+            (key: "size", value: "6+"),
+            (key: "age", value: "10+")
+        ]
+        let query = CIORecommendationsQuery(podID: "item_page_1", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters))
+
+        let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/recommendations/v1/pods/item_page_1?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5Bage%5D=10%2B&filters%5Bsize%5D=6%2B&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results=5&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.recommendations(forQuery: query) { _ in }
+        self.wait(for: builder.expectation)
+    }
+
     func testRecommendations_UsingRecommendationsQueryBuilder_ReturnsNonNilResponse() {
         let query = CIORecommendationsQueryBuilder(podID: "item_page_1").build()
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
@@ -179,6 +179,21 @@ class ConstructorIOSearchTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testSearch_WithPlusSignInQueryParams_ShouldBeEncoded() {
+        let facetFilters = [
+            (key: "size", value: "6+"),
+            (key: "age", value: "10+")
+        ]
+        let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
+        let query = CIOSearchQuery(query: "potato", filters: queryFilters)
+
+        let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/search/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5Bage%5D=10%2B&filters%5Bsize%5D=6%2B&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.search(forQuery: query) { _ in }
+        self.wait(for: builder.expectation)
+    }
+
     func testSearch_UsingSearchQueryBuilder_WithValidRequest_ReturnsNonNilResponse() {
         let query = CIOSearchQueryBuilder(query: "potato").build()
 


### PR DESCRIPTION
### Updates:
* Encode plus sign in query params
    * Not currently handled by Swift's URLComponents since `+` is treated as a space delimiter
    * However, our system expects `+`s in query params to be encoded, otherwise no results are returned
* Tests added 