### PR TITLE
[CSL 1382] Add support for groups sort option + tests

### DIFF
--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		BF380F1C27E28115005E01F5 /* CIOAutocompleteQueryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF380F1B27E28115005E01F5 /* CIOAutocompleteQueryBuilder.swift */; };
 		BF45F3E626E187640069F13E /* NoSessionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EC29B321762BD700DCFA07 /* NoSessionLoader.swift */; };
 		BF67BD3025E71F6E0039D479 /* CIORecommendationsStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF67BD2F25E71F6E0039D479 /* CIORecommendationsStrategy.swift */; };
+		BF684AC92862660000D9007B /* CIOGroupsSortOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF684AC82862660000D9007B /* CIOGroupsSortOption.swift */; };
 		BFC9502625D206C400118D4C /* RecommendationsQueryRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC9502425D206C400118D4C /* RecommendationsQueryRequestBuilderTests.swift */; };
 		BFC9502C25D48CE400118D4C /* AbstractRecommendationsResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC9502B25D48CE400118D4C /* AbstractRecommendationsResponseParser.swift */; };
 		BFC9502E25D48CFD00118D4C /* RecommendationsResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC9502D25D48CFD00118D4C /* RecommendationsResponseParser.swift */; };
@@ -371,6 +372,7 @@
 		BF380F1927E2787C005E01F5 /* CIORecommendationsQueryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQueryBuilder.swift; sourceTree = "<group>"; };
 		BF380F1B27E28115005E01F5 /* CIOAutocompleteQueryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOAutocompleteQueryBuilder.swift; sourceTree = "<group>"; };
 		BF67BD2F25E71F6E0039D479 /* CIORecommendationsStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsStrategy.swift; sourceTree = "<group>"; };
+		BF684AC82862660000D9007B /* CIOGroupsSortOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOGroupsSortOption.swift; sourceTree = "<group>"; };
 		BFC17B2DD098BEA7AF8F0E7E /* Pods-UserApplication.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UserApplication.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UserApplication/Pods-UserApplication.debug.xcconfig"; sourceTree = "<group>"; };
 		BFC9502425D206C400118D4C /* RecommendationsQueryRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationsQueryRequestBuilderTests.swift; sourceTree = "<group>"; };
 		BFC9502B25D48CE400118D4C /* AbstractRecommendationsResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractRecommendationsResponseParser.swift; sourceTree = "<group>"; };
@@ -723,6 +725,7 @@
 				0885D84325718AD10038AE96 /* CIOBrowseQuery.swift */,
 				BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */,
 				F685255A21413D4D00A27FAA /* CIORequestData.swift */,
+				BF684AC82862660000D9007B /* CIOGroupsSortOption.swift */,
 				08FFB76B215EBBF8008CAA7D /* CIOTrackAutocompleteSelectData.swift */,
 				08A7E40C2575E37A000FA02F /* CIOTrackBrowseResultClickData.swift */,
 				08A7E40D2575E37A000FA02F /* CIOTrackBrowseResultsLoadedData.swift */,
@@ -2295,6 +2298,7 @@
 				08289545256C5A85009A00BC /* CIOFilterFacetOption.swift in Sources */,
 				F63808F41F5D47BB00C3B322 /* NetworkClient.swift in Sources */,
 				F63809091F5E854B00C3B322 /* CIOHighlightingAttributesProvider.swift in Sources */,
+				BF684AC92862660000D9007B /* CIOGroupsSortOption.swift in Sources */,
 				BFC9502C25D48CE400118D4C /* AbstractRecommendationsResponseParser.swift in Sources */,
 				F69C2CA4207FAFC60060B2B9 /* CIOPrintLogger.swift in Sources */,
 				086D611923636E6600347771 /* CIOABTestCell.swift in Sources */,

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
@@ -59,6 +59,11 @@ public class CIOBrowseQueryBuilder {
     var hiddenFacets: [String]?
 
     /**
+     The sort method/order for groups
+     */
+    var groupsSortOption: CIOGroupsSortOption?
+
+    /**
      Creata a Browse request query builder
      
      - Parameters:
@@ -127,6 +132,14 @@ public class CIOBrowseQueryBuilder {
     }
 
     /**
+     Add a groups sort option
+     */
+    public func setGroupsSortOption(_ groupsSortOption: CIOGroupsSortOption) -> CIOBrowseQueryBuilder {
+        self.groupsSortOption = groupsSortOption
+        return self
+    }
+
+    /**
      Build the request object set all of the provided data
      
      ### Usage Example: ###
@@ -148,6 +161,6 @@ public class CIOBrowseQueryBuilder {
      ```
      */
     public func build() -> CIOBrowseQuery {
-        return CIOBrowseQuery(filterName: filterName, filterValue: filterValue, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets)
+        return CIOBrowseQuery(filterName: filterName, filterValue: filterValue, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
@@ -54,6 +54,11 @@ public class CIOSearchQueryBuilder {
     var hiddenFacets: [String]?
 
     /**
+     The sort method/order for groups
+     */
+    var groupsSortOption: CIOGroupsSortOption?
+
+    /**
      Creata a Search request query builder
      
      - Parameters:
@@ -118,6 +123,14 @@ public class CIOSearchQueryBuilder {
         self.hiddenFacets = hiddenFacets
         return self
     }
+    
+    /**
+     Add a groups sort option
+     */
+    public func setGroupsSortOption(_ groupsSortOption: CIOGroupsSortOption) -> CIOSearchQueryBuilder {
+        self.groupsSortOption = groupsSortOption
+        return self
+    }
 
     /**
      Build the request object with all of the provided data
@@ -142,6 +155,6 @@ public class CIOSearchQueryBuilder {
      ```
      */
     public func build() -> CIOSearchQuery {
-        return CIOSearchQuery(query: query, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets)
+        return CIOSearchQuery(query: query, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -147,7 +147,7 @@ extension RequestBuilder {
         guard let hiddenField = hiddenField else { return }
         self.set(fmtOption: (key: "hidden_fields", value: hiddenField))
     }
-    
+
     func set(hiddenFacets: [String]?) {
         guard let hiddenFacets = hiddenFacets else { return }
         for hiddenFacet in hiddenFacets {
@@ -159,7 +159,7 @@ extension RequestBuilder {
         guard let hiddenFacet = hiddenFacet else { return }
         self.set(fmtOption: (key: "hidden_facets", value: hiddenFacet))
     }
-    
+
     func set(fmtOptions: [FmtOption]?) {
         guard let options = fmtOptions else { return }
         for option in options {
@@ -170,5 +170,11 @@ extension RequestBuilder {
     func set(fmtOption: FmtOption?) {
         guard let option = fmtOption else { return }
         queryItems.add(URLQueryItem(name: Constants.SearchQuery.fmtOptionsKey(option.key), value: option.value))
+    }
+
+    func set(groupsSortOption: CIOGroupsSortOption?) {
+        guard let option = groupsSortOption else { return }
+        self.set(fmtOption: (key: "groups_sort_by", value: option.sortBy.rawValue))
+        self.set(fmtOption: (key: "groups_sort_order", value: option.sortOrder.rawValue))
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
@@ -56,6 +56,11 @@ public struct CIOBrowseQuery: CIORequestData {
      The list of hidden facet fields to return
      */
     public let hiddenFacets: [String]?
+    
+    /**
+     The sort method/order for groups
+     */
+    public let groupsSortOption: CIOGroupsSortOption?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.BrowseQuery.format, baseURL, filterName, filterValue)
@@ -74,6 +79,7 @@ public struct CIOBrowseQuery: CIORequestData {
         - section: The section to return results from
         - hiddenFields: The list of hidden metadata fields to return
         - hiddenFacets: The list of hidden facest to return
+        - groupsSortOption: The sort method/order for groups
 
      ### Usage Example: ###
      ```
@@ -84,7 +90,7 @@ public struct CIOBrowseQuery: CIORequestData {
      let browseQuery = CIOBrowseQuery(filterName: "group_id", filterValue: "Pantry", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"]))
      ```
      */
-    public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil) {
+    public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil) {
         self.filterName = filterName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filterValue = filterValue.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filters = filters
@@ -94,6 +100,7 @@ public struct CIOBrowseQuery: CIORequestData {
         self.sortOption = sortOption
         self.hiddenFields = hiddenFields
         self.hiddenFacets = hiddenFacets
+        self.groupsSortOption = groupsSortOption
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -105,5 +112,6 @@ public struct CIOBrowseQuery: CIORequestData {
         requestBuilder.set(sortOption: self.sortOption)
         requestBuilder.set(hiddenFields: self.hiddenFields)
         requestBuilder.set(hiddenFacets: self.hiddenFacets)
+        requestBuilder.set(groupsSortOption: self.groupsSortOption)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOGroupsSortOption.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOGroupsSortOption.swift
@@ -1,0 +1,47 @@
+//
+//  CIOGroupsSortOption.swift
+//  Constructor.io
+//
+//  Copyright © Constructor.io. All rights reserved.
+//  http://constructor.io/
+//
+
+import Foundation
+
+/**
+ Struct encapsulating a group sort option
+ */
+public struct CIOGroupsSortOption {
+    /**
+     The sort method ("relevance", "value", or "num_matches")
+     */
+    public let sortBy: CIOGroupsSortBy
+
+    /**
+     The sort order (i.e. "ascending" or "descending")
+     */
+    public let sortOrder: CIOGroupsSortOrder
+    
+    /**
+     Create a groups sort option
+     
+     -  parameters
+        - sortBy: The sort method ("relevance", "value", or "num_matches")
+        - sortOrder: The sort order (i.e. "ascending" or "descending"
+     */
+    public init(sortBy: CIOGroupsSortBy, sortOrder: CIOGroupsSortOrder) {
+        self.sortBy = sortBy
+        self.sortOrder = sortOrder
+    }
+    
+    public enum CIOGroupsSortBy: String {
+        case relevance
+        case value
+        case num_matches
+    }
+    
+    public enum CIOGroupsSortOrder: String {
+        case ascending
+        case descending
+    }
+}

--- a/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
@@ -52,6 +52,11 @@ public struct CIOSearchQuery: CIORequestData {
      */
     public let hiddenFacets: [String]?
 
+    /**
+     The sort method/order for groups
+     */
+    public let groupsSortOption: CIOGroupsSortOption?
+
     func url(with baseURL: String) -> String {
         return String(format: Constants.SearchQuery.format, baseURL, query)
     }
@@ -68,6 +73,7 @@ public struct CIOSearchQuery: CIORequestData {
         - section: The section to return results from
         - hiddenFields: The list of hidden metadata fields to return
         - hiddenFacets: The list of hidden facest to return
+        - groupsSortOption: The sort method/order for groups
      
      ### Usage Example: ###
      ```
@@ -78,7 +84,7 @@ public struct CIOSearchQuery: CIORequestData {
      let searchQuery = CIOSearchQuery(query: "red", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"])
      ```
      */
-    public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil) {
+    public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil) {
         self.query = query.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filters = filters
         self.page = page != nil ? page! : Constants.SearchQuery.defaultPage
@@ -87,6 +93,7 @@ public struct CIOSearchQuery: CIORequestData {
         self.sortOption = sortOption
         self.hiddenFields = hiddenFields
         self.hiddenFacets = hiddenFacets
+        self.groupsSortOption = groupsSortOption
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -98,5 +105,6 @@ public struct CIOSearchQuery: CIORequestData {
         requestBuilder.set(sortOption: self.sortOption)
         requestBuilder.set(hiddenFields: self.hiddenFields)
         requestBuilder.set(hiddenFacets: self.hiddenFacets)
+        requestBuilder.set(groupsSortOption: self.groupsSortOption)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
@@ -137,8 +137,19 @@ class ConstructorIOBrowseTests: XCTestCase {
         let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
         let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet", filters: queryFilters)
 
-        let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with 200 should return a response", builder: http(200))
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5Bage%5D=10%2B&filters%5Bsize%5D=6%2B&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.browse(forQuery: query) { _ in }
+        self.wait(for: builder.expectation)
+    }
+
+    func testBrowse_AttachesGroupsSortOption() {
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+        let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet", groupsSortOption: groupsSortOption)
+
+        let builder = CIOBuilder(expectation: "Calling Browse with groups sort option should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browse(forQuery: query) { _ in }
         self.wait(for: builder.expectation)
@@ -147,7 +158,7 @@ class ConstructorIOBrowseTests: XCTestCase {
     func testBrowse_UsingBrowseQueryBuilder_WithValidRequest_ReturnsNonNilResponse() {
         let query = CIOBrowseQueryBuilder(filterName: "potato", filterValue: "russet").build()
 
-        let builder = CIOBuilder(expectation: "Calling Search with valid parameters should return a non-nil response.", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with valid parameters should return a non-nil response.", builder: http(200))
 
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
 
@@ -162,7 +173,7 @@ class ConstructorIOBrowseTests: XCTestCase {
             .setPerPage(50)
             .build()
 
-        let builder = CIOBuilder(expectation: "Calling Search with valid parameters should return a non-nil response.", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with valid parameters should return a non-nil response.", builder: http(200))
 
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=50&page=5&s=\(kRegexSession)&section=Products"), builder.create())
 
@@ -182,7 +193,7 @@ class ConstructorIOBrowseTests: XCTestCase {
             .setSortOption(sortOption!)
             .build()
 
-        let builder = CIOBuilder(expectation: "Calling Search with valid parameters should return a non-nil response.", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with valid parameters should return a non-nil response.", builder: http(200))
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products&sort_by=relevance&sort_order=descending"), builder.create())
 
         self.constructor.browse(forQuery: query, completionHandler: { response in })
@@ -198,7 +209,7 @@ class ConstructorIOBrowseTests: XCTestCase {
             .setFilters(CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters))
             .build()
 
-        let builder = CIOBuilder(expectation: "Calling Search with multiple facet filters with the same name should have a multiple facet URL query items", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with multiple facet filters with the same name should have a multiple facet URL query items", builder: http(200))
 
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5BfacetOne%5D=Natural&filters%5BfacetOne%5D=Organic&filters%5BfacetOne%5D=Whole-grain&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
 
@@ -213,7 +224,7 @@ class ConstructorIOBrowseTests: XCTestCase {
             .setHiddenFields(hiddenFields)
             .build()
 
-        let builder = CIOBuilder(expectation: "Calling Search with multiple facet filters with the same name should have a multiple facet URL query items", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with multiple facet filters with the same name should have a multiple facet URL query items", builder: http(200))
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bhidden_fields%5D=hidden_field_1&fmt_options%5Bhidden_fields%5D=hidden_field_2&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browse(forQuery: query, completionHandler: { response in })
@@ -227,11 +238,24 @@ class ConstructorIOBrowseTests: XCTestCase {
             .setHiddenFacets(hiddenFacets)
             .build()
 
-        let builder = CIOBuilder(expectation: "Calling Search with multiple facet filters with the same name should have a multiple facet URL query items", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Browse with multiple facet filters with the same name should have a multiple facet URL query items", builder: http(200))
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bhidden_facets%5D=hidden_facet_1&fmt_options%5Bhidden_facets%5D=hidden_facet_2&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browse(forQuery: query, completionHandler: { response in })
 
+        self.wait(for: builder.expectation)
+    }
+
+    func testBrowse_UsingBrowseQueryBuilder_AttachesGroupsSortOption() {
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+        let query = CIOBrowseQueryBuilder(filterName: "potato", filterValue: "russet")
+            .setGroupsSortOption(groupsSortOption)
+            .build()
+
+        let builder = CIOBuilder(expectation: "Calling Browse with groups sort option should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.browse(forQuery: query) { _ in }
         self.wait(for: builder.expectation)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -308,7 +308,6 @@ class ConstructorIOIntegrationTests: XCTestCase {
             let searchResult = responseData.results[0]
             let hiddenFacetIndex = responseData.facets.firstIndex{$0.name == hiddenFacets[0]}
 
-
             XCTAssertNil(cioError)
             XCTAssertNotNil(searchResult)
             XCTAssertEqual(responseData.facets[hiddenFacetIndex!].name, hiddenFacets[0])
@@ -329,6 +328,42 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
+    func testSearch_WithGroupSortOptionValueAscending() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+        let query = CIOSearchQuery(query: "pork", groupsSortOption: groupsSortOption)
+        constructorClient.search(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            let responseData = response.data!
+            let searchResult = responseData.results[0]
+
+            XCTAssertNil(cioError)
+            XCTAssertNotNil(searchResult)
+            XCTAssertEqual(responseData.groups[0].displayName, "Dairy")
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testSearch_WithGroupSortOptionValueDescending() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .descending)
+        let query = CIOSearchQuery(query: "pork", groupsSortOption: groupsSortOption)
+        constructorClient.search(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            let responseData = response.data!
+            let searchResult = responseData.results[0]
+
+            XCTAssertNil(cioError)
+            XCTAssertNotNil(searchResult)
+            XCTAssertEqual(responseData.groups[0].displayName, "Meat & Poultry")
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
     func testBrowse() {
         let expectation = XCTestExpectation(description: "Request 204")
         let query = CIOBrowseQuery(filterName: "group_id", filterValue: "431")
@@ -339,7 +374,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowseWithCollections() {
         let expectation = XCTestExpectation(description: "Request 204")
         let query = CIOBrowseQuery(filterName: "collection_id", filterValue: "fresh-fruits")
@@ -348,7 +383,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
             let responseData = response.data!
             let displayName = responseData.collection?.display_name
             let collectionId = responseData.collection?.id
-            
+
             XCTAssertNil(cioError)
             XCTAssertEqual(displayName, "fresh fruits", "Collection display name matches the provided collection display name")
             XCTAssertEqual(collectionId, "fresh-fruits", "Collection id matches the provided collection id")
@@ -392,7 +427,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowse_WithHiddenFacets() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 204")
@@ -431,6 +466,44 @@ class ConstructorIOIntegrationTests: XCTestCase {
             let cioError = response.error as? CIOError
             XCTAssertNotNil(cioError)
             XCTAssertEqual(cioError?.errorMessage, "You\'re trying to access an invalid endpoint. Please check documentation for allowed endpoints.")
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testBrowse_WithGroupSortOptionValueAscending() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "431", groupsSortOption: groupsSortOption)
+        constructorClient.browse(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            let responseData = response.data!
+            let searchResult = responseData.results[0]
+
+            XCTAssertNil(cioError)
+            XCTAssertNotNil(searchResult)
+            XCTAssertEqual(responseData.groups[0].displayName, "Grocery")
+            XCTAssertEqual(responseData.groups[0].children[0].displayName, "Baby")
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testBrowse_WithGroupSortOptionValueDescending() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .descending)
+        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "431", groupsSortOption: groupsSortOption)
+        constructorClient.browse(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            let responseData = response.data!
+            let searchResult = responseData.results[0]
+
+            XCTAssertNil(cioError)
+            XCTAssertNotNil(searchResult)
+            XCTAssertEqual(responseData.groups[0].displayName, "Grocery")
+            XCTAssertEqual(responseData.groups[0].children[0].displayName, "Pet")
             expectation.fulfill()
         })
         self.wait(for: expectation)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
@@ -187,8 +187,19 @@ class ConstructorIOSearchTests: XCTestCase {
         let queryFilters = CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters)
         let query = CIOSearchQuery(query: "potato", filters: queryFilters)
 
-        let builder = CIOBuilder(expectation: "Calling Autocomplete with 200 should return a response", builder: http(200))
+        let builder = CIOBuilder(expectation: "Calling Search with 200 should return a response", builder: http(200))
         stub(regex("https://ac.cnstrc.com/search/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&filters%5Bage%5D=10%2B&filters%5Bsize%5D=6%2B&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.search(forQuery: query) { _ in }
+        self.wait(for: builder.expectation)
+    }
+
+    func testSearch_AttachesGroupsSortOption() {
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+        let query = CIOSearchQuery(query: "potato", groupsSortOption: groupsSortOption)
+
+        let builder = CIOBuilder(expectation: "Calling Search with 200 should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/search/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.search(forQuery: query) { _ in }
         self.wait(for: builder.expectation)
@@ -281,6 +292,19 @@ class ConstructorIOSearchTests: XCTestCase {
 
         self.constructor.search(forQuery: query, completionHandler: { response in })
 
+        self.wait(for: builder.expectation)
+    }
+
+    func testSearch_UsingSearchQueryBuilder_AttachesGroupsSortOption() {
+        let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+        let query = CIOSearchQueryBuilder(query: "potato")
+            .setGroupsSortOption(groupsSortOption)
+            .build()
+
+        let builder = CIOBuilder(expectation: "Calling Search with 200 should return a response", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/search/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products"), builder.create())
+
+        self.constructor.search(forQuery: query) { _ in }
         self.wait(for: builder.expectation)
     }
 }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ let filters = CIOQueryFilters(groupFilter: "Bread", facetFilters: [
 let query = CIOSearchQuery(query: "Dave's Bread", page: 5, filters: filters)
 
 // Specify the sort order in which groups are returned
-let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+let groupsSortOption = CIOGroupsSortOption(sortBy: CIOGroupsSortBy.value, sortOrder: CIOGroupsSortOrder.ascending)
 
 constructor.search(forQuery: query, filters: filters, groupsSortOption: groupsSortOption) { (response) in
   let data = response.data!
@@ -101,7 +101,7 @@ constructor.search(forQuery: query, filters: filters, groupsSortOption: groupsSo
 let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet")
 
 // Specify the sort order in which groups are returned
-let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+let groupsSortOption = CIOGroupsSortOption(sortBy: CIOGroupsSortBy.value, sortOrder: CIOGroupsSortOrder.ascending)
 
 constructor.browse(forQuery: query, groupsSortOption: groupsSortOption) { (response) in
   let data = response.data!

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ let filters = CIOQueryFilters(groupFilter: "Bread", facetFilters: [
 ])
 let query = CIOSearchQuery(query: "Dave's Bread", page: 5, filters: filters)
 
-constructor.search(forQuery: query) { (response) in
+// Specify the sort order in which groups are returned
+let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+
+constructor.search(forQuery: query, filters: filters, groupsSortOption: groupsSortOption) { (response) in
   let data = response.data!
   let error = response.error!
   // ...
@@ -97,7 +100,10 @@ constructor.search(forQuery: query) { (response) in
 ```swift
 let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet")
 
-constructor.browse(forQuery: query) { (response) in
+// Specify the sort order in which groups are returned
+let groupsSortOption = CIOGroupsSortOption(sortBy: .value, sortOrder: .ascending)
+
+constructor.browse(forQuery: query, groupsSortOption: groupsSortOption) { (response) in
   let data = response.data!
   let error = response.error!
   // ...


### PR DESCRIPTION
### Updates:
* Add support for groups sort format option + tests
* `fmt_options[groups_sort_by]`
    * Possible values are `relevance`, `num_matches` or `value`.
* `fmt_options[groups_sort_order]`
    * Possible values are `ascending` or `descending`.