### PR TITLE
[CSL 1424] Fix parent groups

### DIFF
--- a/AutocompleteClient/FW/Logic/Result/CIOFilterGroup.swift
+++ b/AutocompleteClient/FW/Logic/Result/CIOFilterGroup.swift
@@ -26,7 +26,7 @@ public class CIOFilterGroup: NSObject {
     /**
      The number of results that would be returned when selected
      */
-    public let count: Int
+    public let count: Int?
 
     /**
      List of child groups
@@ -47,13 +47,13 @@ public class CIOFilterGroup: NSObject {
     init?(json: JSONObject) {
         guard let name = json["display_name"] as? String else { return nil }
         guard let groupID = json["group_id"] as? String else { return nil }
-        guard let count = json["count"] as? Int else { return nil }
 
         let childrenObj = json["children"] as? [JSONObject]
         let parentObj = json["parents"] as? [JSONObject]
 
         let children: [CIOFilterGroup] = childrenObj?.compactMap { obj in return CIOFilterGroup(json: obj) } ?? []
         let parents: [CIOFilterGroup] = parentObj?.compactMap { obj in return CIOFilterGroup(json: obj) } ?? []
+        let count = json["count"] as? Int
 
         self.displayName = name
         self.groupID = groupID

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -261,6 +261,21 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
+    func testSearch_ShouldReturnGroupsWithParents() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let query = CIOSearchQuery(query: "a")
+        self.constructor.search(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            let responseData = response.data!
+            let groups = responseData.groups
+
+            XCTAssertFalse(groups[0].children[0].parents.isEmpty)
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
     func testSearch_WithFilters() {
         let expectation = XCTestExpectation(description: "Request 204")
         let facetFilters = [
@@ -369,6 +384,21 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let query = CIOBrowseQuery(filterName: "group_id", filterValue: "431")
         self.constructor.browse(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testBrowseShouldReturnGroupsWithParents() {
+        let expectation = XCTestExpectation(description: "Request 204")
+        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "39")
+        self.constructor.browse(forQuery: query, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            let responseData = response.data!
+            let groups = responseData.groups
+
+            XCTAssertFalse(groups[0].parents.isEmpty)
             XCTAssertNil(cioError)
             expectation.fulfill()
         })

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -261,7 +261,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testSearch_ShouldReturnGroupsWithParents() {
+    func testSearch_ShouldReturnGroupsWithParentsAndChildren() {
         let expectation = XCTestExpectation(description: "Request 204")
         let query = CIOSearchQuery(query: "a")
         self.constructor.search(forQuery: query, completionHandler: { response in
@@ -269,6 +269,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
             let responseData = response.data!
             let groups = responseData.groups
 
+            XCTAssertFalse(groups[0].children.isEmpty)
             XCTAssertFalse(groups[0].children[0].parents.isEmpty)
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -390,15 +391,16 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testBrowseShouldReturnGroupsWithParents() {
+    func testBrowseShouldReturnGroupsWithParentsAndChildren() {
         let expectation = XCTestExpectation(description: "Request 204")
-        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "39")
+        let query = CIOBrowseQuery(filterName: "group_id", filterValue: "600")
         self.constructor.browse(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
             let groups = responseData.groups
 
             XCTAssertFalse(groups[0].parents.isEmpty)
+            XCTAssertFalse(groups[0].children.isEmpty)
             XCTAssertNil(cioError)
             expectation.fulfill()
         })


### PR DESCRIPTION
### Updates:
* Resolves issue with parent groups not being returned in client responses due to parent groups not containing a count property causing nil to be returned during deserialization
* Added two new tests to check for parents and children for search/browse (All tests pass, except for a hidden field one which is a separate issue) 