### PR TITLE
[CSL 1565] Add support for variation ids in behavioral events

### DIFF
--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		8DF2172D2888AE5E006384A5 /* CIOResultSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */; };
 		8DF2172F2888B56D006384A5 /* CIOResultSourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */; };
 		99D6877853DE657CAF7E876C /* Pods_UserApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D938EAC4478309F3008F3B0D /* Pods_UserApplication.framework */; };
+		BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOItem.swift */; };
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
@@ -370,6 +371,7 @@
 		8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSources.swift; sourceTree = "<group>"; };
 		8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSourceData.swift; sourceTree = "<group>"; };
 		A466AF5E4660C198B64CE5CE /* Pods-AutocompleteClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutocompleteClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutocompleteClientTests/Pods-AutocompleteClientTests.release.xcconfig"; sourceTree = "<group>"; };
+		BF02E29E28B5739C0062B44F /* CIOItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOItem.swift; sourceTree = "<group>"; };
 		BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQuery.swift; sourceTree = "<group>"; };
 		BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsResponse.swift; sourceTree = "<group>"; };
 		BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsPod.swift; sourceTree = "<group>"; };
@@ -744,6 +746,7 @@
 				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
 				08FFB76D215EC1DF008CAA7D /* CIOTrackSearchSubmitData.swift */,
 				F685255C21414E1D00A27FAA /* CIOTrackSessionStartData.swift */,
+				BF02E29E28B5739C0062B44F /* CIOItem.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2263,6 +2266,7 @@
 				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchResultClickData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
+				BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */,
 				F638090B1F5E855B00C3B322 /* BoldAttributesProvider.swift in Sources */,
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,

--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -64,7 +64,6 @@
 		8DF2172D2888AE5E006384A5 /* CIOResultSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */; };
 		8DF2172F2888B56D006384A5 /* CIOResultSourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */; };
 		99D6877853DE657CAF7E876C /* Pods_UserApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D938EAC4478309F3008F3B0D /* Pods_UserApplication.framework */; };
-		BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOItem.swift */; };
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
@@ -371,7 +370,6 @@
 		8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSources.swift; sourceTree = "<group>"; };
 		8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSourceData.swift; sourceTree = "<group>"; };
 		A466AF5E4660C198B64CE5CE /* Pods-AutocompleteClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutocompleteClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutocompleteClientTests/Pods-AutocompleteClientTests.release.xcconfig"; sourceTree = "<group>"; };
-		BF02E29E28B5739C0062B44F /* CIOItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOItem.swift; sourceTree = "<group>"; };
 		BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQuery.swift; sourceTree = "<group>"; };
 		BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsResponse.swift; sourceTree = "<group>"; };
 		BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsPod.swift; sourceTree = "<group>"; };
@@ -746,7 +744,6 @@
 				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
 				08FFB76D215EC1DF008CAA7D /* CIOTrackSearchSubmitData.swift */,
 				F685255C21414E1D00A27FAA /* CIOTrackSessionStartData.swift */,
-				BF02E29E28B5739C0062B44F /* CIOItem.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2266,7 +2263,6 @@
 				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchResultClickData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
-				BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */,
 				F638090B1F5E855B00C3B322 /* BoldAttributesProvider.swift in Sources */,
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,

--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -145,6 +145,7 @@ struct Constants {
         static let name = "name"
         static let customerID = "customer_id"
         static let customerIDs = "customer_ids"
+        static let variationID = "variation_id"
         static let resultID = "result_id"
         static let revenue = "revenue"
         static let dateTime = "_dt"

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
@@ -52,7 +52,7 @@ public class CIOSearchQueryBuilder {
      The list of hidden facets to return
      */
     var hiddenFacets: [String]?
-    
+
     /**
      The variation map to use with the result set
      */

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -45,6 +45,11 @@ extension RequestBuilder {
         queryItems.add(URLQueryItem(name: Constants.Track.customerIDs, value: customerIDs.prefix(60).joined(separator: ",")))
     }
 
+    func set(variationID: String?) {
+        guard let variationID = variationID else { return }
+        queryItems.add(URLQueryItem(name: Constants.Track.variationID, value: variationID))
+    }
+
     func set(resultID: String?) {
         guard let resultID = resultID else { return }
         queryItems.add(URLQueryItem(name: Constants.Track.resultID, value: resultID))

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackBrowseResultClickData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackBrowseResultClickData.swift
@@ -19,18 +19,20 @@ struct CIOTrackBrowseResultClickData: CIORequestData {
     let resultPositionOnPage: Int?
     var sectionName: String?
     let resultID: String?
+    let variationID: String?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackBrowseResultClick.format, baseURL)
     }
 
-    init(filterName: String, filterValue: String, customerID: String, resultPositionOnPage: Int?, sectionName: String? = nil, resultID: String? = nil) {
+    init(filterName: String, filterValue: String, customerID: String, resultPositionOnPage: Int?, sectionName: String? = nil, resultID: String? = nil, variationID: String? = nil) {
         self.filterName = filterName
         self.filterValue = filterValue
         self.customerID = customerID
         self.resultPositionOnPage = resultPositionOnPage
         self.sectionName = sectionName
         self.resultID = resultID
+        self.variationID = variationID
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {}
@@ -43,9 +45,12 @@ struct CIOTrackBrowseResultClickData: CIORequestData {
         var dict = [
             "filter_name": self.filterName,
             "filter_value": self.filterValue,
-            "item_id": self.customerID
+            "item_id": self.customerID,
         ] as [String: Any]
 
+        if self.variationID != nil {
+            dict["variation_id"] = self.variationID
+        }
         if self.resultPositionOnPage != nil {
             dict["result_position_on_page"] = Int(self.resultPositionOnPage!)
         }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackConversionData.swift
@@ -19,18 +19,20 @@ struct CIOTrackConversionData: CIORequestData {
     var sectionName: String?
     let revenue: Double?
     let conversionType: String?
+    let variationID: String?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackConversion.format, baseURL)
     }
 
-    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil) {
+    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, revenue: Double? = nil, conversionType: String? = nil, variationID: String? = nil) {
         self.searchTerm = searchTerm
         self.itemName = itemName
         self.customerID = customerID
         self.sectionName = sectionName
         self.revenue = revenue
         self.conversionType = conversionType
+        self.variationID = variationID
     }
 
     func httpMethod() -> String {
@@ -48,6 +50,9 @@ struct CIOTrackConversionData: CIORequestData {
             "item_name": self.itemName
         ] as [String: Any]
 
+        if self.variationID != nil {
+            dict["variation_id"] = self.variationID
+        }
         if self.revenue != nil {
             dict["revenue"] = NSString(format: "%.2f", self.revenue!)
         }

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackSearchResultClickData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackSearchResultClickData.swift
@@ -17,17 +17,19 @@ struct CIOTrackSearchResultClickData: CIORequestData {
     let customerID: String
     var sectionName: String?
     let resultID: String?
+    let variationID: String?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackSearchResultClick.format, baseURL, self.searchTerm.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!)
     }
 
-    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, resultID: String? = nil) {
+    init(searchTerm: String, itemName: String, customerID: String, sectionName: String? = nil, resultID: String? = nil, variationID: String? = nil) {
         self.searchTerm = searchTerm
         self.itemName = itemName
         self.customerID = customerID
         self.sectionName = sectionName
         self.resultID = resultID
+        self.variationID = variationID
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -35,5 +37,6 @@ struct CIOTrackSearchResultClickData: CIORequestData {
         requestBuilder.set(customerID: self.customerID)
         requestBuilder.set(autocompleteSection: self.sectionName)
         requestBuilder.set(resultID: self.resultID)
+        requestBuilder.set(variationID: self.variationID)
     }
 }

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -253,6 +253,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      - Parameters:
         - itemName: The item name.
         - customerID: The item ID.
+        - variationID: The variation ID
         - searchTerm: The term that the user searched for (defaults to 'TERM_UNKNOWN')
         - sectionName: The name of the autocomplete section the term came from (defaults to "products")
         - resultID: Identifier of result set
@@ -260,13 +261,13 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      
      ### Usage Example: ###
      ```
-     constructorIO.trackSearchResultClick(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", searchTerm: "tooth", sectionName: "Products",  resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
+     constructorIO.trackSearchResultClick(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", variationID: "1234567-AB-7463", searchTerm: "tooth", sectionName: "Products",  resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
      ```
      */
-    public func trackSearchResultClick(itemName: String, customerID: String, searchTerm: String? = nil, sectionName: String? = nil, resultID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackSearchResultClick(itemName: String, customerID: String, variationID: String? = nil, searchTerm: String? = nil, sectionName: String? = nil, resultID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
         let term = searchTerm == nil ? "TERM_UNKNOWN" : (searchTerm!.isEmpty) ? "TERM_UNKNOWN" : searchTerm
-        let data = CIOTrackSearchResultClickData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, resultID: resultID)
+        let data = CIOTrackSearchResultClickData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, resultID: resultID, variationID: variationID)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -297,6 +298,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
      - Parameters:
         - customerID: The item ID.
+        - variationID: The variation ID
         - filterName: The name of the primary filter that the user browsed for (i.e "color")
         - filterValue: The value of the primary filter that the user browsed for (i.e "blue")
         - resultPositionOnPage: The position of clicked item
@@ -306,12 +308,12 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      
      ### Usage Example: ###
      ```
-     constructorIO.trackBrowseResultClick(filterName: "Category", filterValue: "Snacks", customerID: "7654321-BA", resultPositionOnPage: 4, sectionName: "Products", resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
+     constructorIO.trackBrowseResultClick(filterName: "Category", filterValue: "Snacks", customerID: "7654321-BA", variationID: "7654321-BA-738", resultPositionOnPage: 4, sectionName: "Products", resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
      ```
      */
-    public func trackBrowseResultClick(customerID: String, filterName: String, filterValue: String, resultPositionOnPage: Int?, sectionName: String? = nil, resultID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackBrowseResultClick(customerID: String, variationID: String? = nil, filterName: String, filterValue: String, resultPositionOnPage: Int?, sectionName: String? = nil, resultID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackBrowseResultClickData(filterName: filterName, filterValue: filterValue, customerID: customerID, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID)
+        let data = CIOTrackBrowseResultClickData(filterName: filterName, filterValue: filterValue, customerID: customerID, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, variationID: variationID)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -374,6 +376,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      - Parameters:
         - itemName: The item name.
         - customerID: The item ID.
+        - variationID: The variation ID
         - revenue: The  revenue of the item.
         - searchTerm: The term that the user searched for if searching (defaults to 'TERM_UNKNOWN')
         - conversionType: The type of conversion (defaults to "add_to_cart")
@@ -382,14 +385,14 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      
      ### Usage Example: ###
      ```
-     constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", revenue: 12.99, searchTerm: "tooth", conversionType: "add_to_cart")
+     constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", variationID: "1234567-AB-47398", revenue: 12.99, searchTerm: "tooth", conversionType: "add_to_cart")
      ```
      */
-    public func trackConversion(itemName: String, customerID: String, revenue: Double?, searchTerm: String? = nil, sectionName: String? = nil, conversionType: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackConversion(itemName: String, customerID: String, variationID: String? = nil, revenue: Double?, searchTerm: String? = nil, sectionName: String? = nil, conversionType: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
         let type = conversionType ?? Constants.Track.defaultConversionType
         let term = searchTerm == nil ? "TERM_UNKNOWN" : (searchTerm!.isEmpty) ? "TERM_UNKNOWN" : searchTerm
-        let data = CIOTrackConversionData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, revenue: revenue, conversionType: type)
+        let data = CIOTrackConversionData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, revenue: revenue, conversionType: type, variationID: variationID)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackBrowseResultClickRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackBrowseResultClickRequestBuilder.swift
@@ -16,6 +16,7 @@ class TrackBrowseResultClickRequestBuilderTests: XCTestCase {
     fileprivate let filterValue = "russet"
     fileprivate let resultPositionOnPage = 3
     fileprivate let customerID = "custIDq3 qd"
+    fileprivate let variationID = "varID123"
     fileprivate let sectionName = "some section name@"
 
     fileprivate var builder: RequestBuilder!
@@ -35,6 +36,22 @@ class TrackBrowseResultClickRequestBuilderTests: XCTestCase {
         XCTAssertEqual(payload?["filter_name"] as? String, filterName)
         XCTAssertEqual(payload?["filter_value"] as? String, filterValue)
         XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["result_position_on_page"] as? Int, resultPositionOnPage)
+        XCTAssertEqual(payload?["key"] as? String, testACKey)
+        XCTAssertTrue((payload?["c"] as? String)!.contains("cioios-"))
+    }
+
+    func testTrackBrowseResultClickBuilder_WithVariationID() {
+        let tracker = CIOTrackBrowseResultClickData(filterName: filterName, filterValue: filterValue, customerID: customerID, resultPositionOnPage: resultPositionOnPage, variationID: variationID)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(payload?["filter_name"] as? String, filterName)
+        XCTAssertEqual(payload?["filter_value"] as? String, filterValue)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["variation_id"] as? String, variationID)
         XCTAssertEqual(payload?["result_position_on_page"] as? Int, resultPositionOnPage)
         XCTAssertEqual(payload?["key"] as? String, testACKey)
         XCTAssertTrue((payload?["c"] as? String)!.contains("cioios-"))

--- a/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackConversionRequestBuilderTests.swift
@@ -15,6 +15,7 @@ class TrackConversionRequestBuilderTests: XCTestCase {
     fileprivate let searchTerm = "test search term"
     fileprivate let itemName = "some item name"
     fileprivate let customerID = "custIDq3éû qd"
+    fileprivate let variationID = "varID123"
     fileprivate let sectionName = "some section name@"
     fileprivate let conversionType = "like"
     fileprivate let revenue = 12.45
@@ -81,6 +82,25 @@ class TrackConversionRequestBuilderTests: XCTestCase {
         XCTAssertEqual(payload?["section"] as? String, sectionName)
         XCTAssertEqual(payload?["item_name"] as? String, itemName)
         XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
+    }
+
+    func testTrackConversionBuilder_WithVariationID() {
+        let tracker = CIOTrackConversionData(searchTerm: self.searchTerm, itemName: self.itemName, customerID: self.customerID, sectionName: sectionName, variationID: self.variationID)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/conversion?"))
+        XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
+        XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the section.")
+        XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key.")
+        XCTAssertEqual(payload?["section"] as? String, sectionName)
+        XCTAssertEqual(payload?["item_name"] as? String, itemName)
+        XCTAssertEqual(payload?["item_id"] as? String, customerID)
+        XCTAssertEqual(payload?["variation_id"] as? String, variationID)
         XCTAssertEqual(payload?["search_term"] as? String, searchTerm)
     }
 

--- a/AutocompleteClientTests/FW/Logic/Request/TrackSearchResultClickRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackSearchResultClickRequestBuilder.swift
@@ -15,11 +15,13 @@ class TrackSearchResultClickRequestBuilderTests: XCTestCase {
     fileprivate let searchTerm = "test search term"
     fileprivate let itemName = "some item name"
     fileprivate let customerID = "custIDq3 qd"
+    fileprivate let variationID = "varID123"
     fileprivate let sectionName = "some section name@"
 
     fileprivate var encodedSearchTerm: String = ""
     fileprivate var encodedItemName: String = ""
     fileprivate var encodedCustomerID: String = ""
+    fileprivate var encodedVariationID: String = ""
     fileprivate var encodedSectionName: String = ""
 
     fileprivate var builder: RequestBuilder!
@@ -29,6 +31,7 @@ class TrackSearchResultClickRequestBuilderTests: XCTestCase {
         self.encodedSearchTerm = searchTerm.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.encodedItemName = itemName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         self.encodedCustomerID = customerID.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        self.encodedVariationID = variationID.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         self.encodedSectionName = self.sectionName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         self.builder = RequestBuilder(apiKey: testACKey, baseURL: Constants.Query.baseURLString)
     }
@@ -69,6 +72,23 @@ class TrackSearchResultClickRequestBuilderTests: XCTestCase {
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/click_through?"))
         XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item name.")
         XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
+        XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
+        XCTAssertTrue(url.contains("c=\(Constants.versionString())"), "URL should contain the version string")
+        XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key")
+    }
+
+    func testTrackSearchResultClickBuilder_WithVariationID() {
+        let tracker = CIOTrackSearchResultClickData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, sectionName: sectionName, variationID: variationID)
+
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/autocomplete/\(encodedSearchTerm)/click_through?"))
+        XCTAssertTrue(url.contains("name=\(encodedItemName)"), "URL should contain the item name.")
+        XCTAssertTrue(url.contains("customer_id=\(encodedCustomerID)"), "URL should contain the customer ID.")
+        XCTAssertTrue(url.contains("variation_id=\(variationID)"), "URL should contain the variation ID.")
         XCTAssertTrue(url.contains("section=\(encodedSectionName)"), "URL should contain the autocomplete section name.")
         XCTAssertTrue(url.contains("c=\(Constants.versionString())"), "URL should contain the version string")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain the api key")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -97,6 +97,16 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
+    func testSearchResultClick_WithVariationID() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        constructorClient.trackSearchResultClick(itemName: "Item1", customerID: "10001", variationID: "20001", searchTerm: "item", sectionName: "Products", completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+    }
+
     func testBrowseResultsLoaded() {
         let expectation = XCTestExpectation(description: "Tracking 204")
         self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: nil, completionHandler: { response in
@@ -115,6 +125,16 @@ class ConstructorIOIntegrationTests: XCTestCase {
             expectation.fulfill()
         })
         self.wait(for: expectation)
+    }
+
+    func testBrowseResultClick_WithVariationID() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        constructorClient.trackBrowseResultClick(customerID: "10001", variationID: "20001", filterName: "Brand", filterValue: "XYZ", resultPositionOnPage: 1, sectionName: "Products", completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
     }
 
     func testRecommendationsResultsView() {
@@ -145,6 +165,16 @@ class ConstructorIOIntegrationTests: XCTestCase {
             expectation.fulfill()
         })
         self.wait(for: expectation)
+    }
+
+    func testConversion_WithVariationID() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
+        let expectation = XCTestExpectation(description: "Request 204")
+        constructorClient.trackConversion(itemName: "Item 1", customerID: "10001", variationID: "20001", revenue: 10, searchTerm: "item", sectionName: "Products", completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
     }
 
     func testPurchase() {

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultClickTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultClickTests.swift
@@ -45,6 +45,18 @@ class ConstructorIOTrackBrowseResultClickTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testTrackBrowseResultClick_WithVariationID() {
+        let filterName = "potato"
+        let filterValue = "russet"
+        let customerID = "customerID123"
+        let variationID = "variationID456"
+        let sectionName = "Search Suggestions"
+        let builder = CIOBuilder(expectation: "Calling trackBrowseResultClick should send a valid request with a section name.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_click?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), builder.create())
+        self.constructor.trackBrowseResultClick(customerID: customerID, variationID: variationID, filterName: filterName, filterValue: filterValue, resultPositionOnPage: nil, sectionName: sectionName)
+        self.wait(for: builder.expectation)
+    }
+
     func testTrackBrowseResultClick_WithResultID() {
         let filterName = "potato"
         let filterValue = "russet"
@@ -52,7 +64,7 @@ class ConstructorIOTrackBrowseResultClickTests: XCTestCase {
         let resultID = "0123456789"
         let builder = CIOBuilder(expectation: "Calling trackBrowseResultClick should send a valid request with a section name.", builder: http(200))
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_click?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), builder.create())
-        self.constructor.trackBrowseResultClick(customerID: customerID, filterName: filterName, filterValue: filterValue, resultPositionOnPage: nil,    sectionName: nil, resultID: resultID)
+        self.constructor.trackBrowseResultClick(customerID: customerID, filterName: filterName, filterValue: filterValue, resultPositionOnPage: nil, sectionName: nil, resultID: resultID)
         self.wait(for: builder.expectation)
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackConversionTests.swift
@@ -67,6 +67,19 @@ class ConstructorIOTrackConversionTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testTrackConversion_WithVariationID() {
+        let searchTerm = "corn"
+        let itemName = "green-giant-corn-can-12oz"
+        let customerID = "customerID123"
+        let variationID = "variationID456"
+        let revenue: Double = 1
+        let sectionName = "Search Suggestions"
+        let builder = CIOBuilder(expectation: "Calling trackConversion should send a valid request with a section name.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/conversion?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Search%20Suggestions"), builder.create())
+        self.constructor.trackConversion(itemName: itemName, customerID: customerID, variationID: variationID, revenue: revenue, searchTerm: searchTerm, sectionName: sectionName)
+        self.wait(for: builder.expectation)
+    }
+
     func testTrackConversion_WithType() {
         let searchTerm = "corn"
         let itemName = "green-giant-corn-can-12oz"

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackSearchResultClickTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackSearchResultClickTests.swift
@@ -53,6 +53,18 @@ class ConstructorIOTrackSearchResultClickTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testTrackSearchResultClick_WithVariationID() {
+        let searchTerm = "corn"
+        let itemName = "green-giant-corn-can-12oz"
+        let customerID = "customerID123"
+        let variationID = "variationID456"
+        let sectionName = "Search Suggestions"
+        let builder = CIOBuilder(expectation: "Calling trackSearchResultClick should send a valid request with a section name.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/click_through?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&customer_id=customerID123&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&name=green-giant-corn-can-12oz&s=\(kRegexSession)&section=Search%20Suggestions&variation_id=variationID456"), builder.create())
+        self.constructor.trackSearchResultClick(itemName: itemName, customerID: customerID, variationID: variationID, searchTerm: searchTerm, sectionName: sectionName)
+        self.wait(for: builder.expectation)
+    }
+
     func testTrackSearchResultClick_WithSection() {
         let searchTerm = "corn"
         let itemName = "green-giant-corn-can-12oz"

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ constructorIO.trackSearchSubmit(searchTerm: "toothpicks", originalQuery: "tooth"
 constructorIO.trackSearchResultsLoaded(searchTerm: "tooth", resultCount: 789, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"])
 
 // Track when a search result is clicked
-constructorIO.trackSearchResultClick(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", searchTerm: "tooth", sectionName: "Products",  resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
+constructorIO.trackSearchResultClick(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", variationID: "1234567-AB-7463", searchTerm: "tooth", sectionName: "Products",  resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
 ```
 
 ### Browse Events
@@ -195,7 +195,7 @@ constructorIO.trackSearchResultClick(itemName: "Fashionable Toothpicks", custome
 constructorIO.trackBrowseResultsLoaded(filterName: "Category", filterValue: "Snacks", resultCount: 674)
 
 // Track when a browse result is clicked
-constructorIO.trackBrowseResultClick(filterName: "Category", filterValue: "Snacks", customerID: "7654321-BA", resultPositionOnPage: 4, sectionName: "Products", resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
+constructorIO.trackBrowseResultClick(filterName: "Category", filterValue: "Snacks", customerID: "7654321-BA", variationID: "7654321-BA-738", resultPositionOnPage: 4, sectionName: "Products", resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
 ```
 
 ### Recommendations Events
@@ -212,7 +212,7 @@ constructorIO.trackRecommendationResultClick(podID: "pdp_best_sellers", strategy
 
 ```swift
 // Track when an item converts (a.k.a. is added to cart) regardless of the user journey that led to adding to cart
-constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", revenue: 12.99, searchTerm: "tooth", conversionType: "add_to_cart")
+constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1234567-AB", variationID: "1234567-AB-47398", revenue: 12.99, searchTerm: "tooth", conversionType: "add_to_cart")
 
 // Track when items are purchased
 constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")


### PR DESCRIPTION
### Updates:
* Add variation ids to all behavioral events that support it (already supported in recommendation result click)
    * Browse Result Click
    * Search Result Click
    * Conversion
* Add/Update tests (all tests pass)
* Update README examples

Separate PR for purchase events: https://github.com/Constructor-io/constructorio-client-swift/pull/148