### PR TITLE
[CSL 1565] Support variation ids in purchase events

### DIFF
--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		8DF2172D2888AE5E006384A5 /* CIOResultSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */; };
 		8DF2172F2888B56D006384A5 /* CIOResultSourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */; };
 		99D6877853DE657CAF7E876C /* Pods_UserApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D938EAC4478309F3008F3B0D /* Pods_UserApplication.framework */; };
+		BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOItem.swift */; };
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
@@ -370,6 +371,7 @@
 		8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSources.swift; sourceTree = "<group>"; };
 		8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSourceData.swift; sourceTree = "<group>"; };
 		A466AF5E4660C198B64CE5CE /* Pods-AutocompleteClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutocompleteClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutocompleteClientTests/Pods-AutocompleteClientTests.release.xcconfig"; sourceTree = "<group>"; };
+		BF02E29E28B5739C0062B44F /* CIOItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOItem.swift; sourceTree = "<group>"; };
 		BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQuery.swift; sourceTree = "<group>"; };
 		BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsResponse.swift; sourceTree = "<group>"; };
 		BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsPod.swift; sourceTree = "<group>"; };
@@ -744,6 +746,7 @@
 				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
 				08FFB76D215EC1DF008CAA7D /* CIOTrackSearchSubmitData.swift */,
 				F685255C21414E1D00A27FAA /* CIOTrackSessionStartData.swift */,
+				BF02E29E28B5739C0062B44F /* CIOItem.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2263,6 +2266,7 @@
 				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchResultClickData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
+				BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */,
 				F638090B1F5E855B00C3B322 /* BoldAttributesProvider.swift in Sources */,
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,

--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		8DF2172D2888AE5E006384A5 /* CIOResultSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */; };
 		8DF2172F2888B56D006384A5 /* CIOResultSourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */; };
 		99D6877853DE657CAF7E876C /* Pods_UserApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D938EAC4478309F3008F3B0D /* Pods_UserApplication.framework */; };
-		BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOItem.swift */; };
+		BF02E29F28B5739C0062B44F /* CIOPurchaseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOPurchaseItem.swift */; };
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
@@ -371,7 +371,7 @@
 		8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSources.swift; sourceTree = "<group>"; };
 		8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSourceData.swift; sourceTree = "<group>"; };
 		A466AF5E4660C198B64CE5CE /* Pods-AutocompleteClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutocompleteClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutocompleteClientTests/Pods-AutocompleteClientTests.release.xcconfig"; sourceTree = "<group>"; };
-		BF02E29E28B5739C0062B44F /* CIOItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOItem.swift; sourceTree = "<group>"; };
+		BF02E29E28B5739C0062B44F /* CIOPurchaseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOPurchaseItem.swift; sourceTree = "<group>"; };
 		BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQuery.swift; sourceTree = "<group>"; };
 		BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsResponse.swift; sourceTree = "<group>"; };
 		BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsPod.swift; sourceTree = "<group>"; };
@@ -746,7 +746,7 @@
 				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
 				08FFB76D215EC1DF008CAA7D /* CIOTrackSearchSubmitData.swift */,
 				F685255C21414E1D00A27FAA /* CIOTrackSessionStartData.swift */,
-				BF02E29E28B5739C0062B44F /* CIOItem.swift */,
+				BF02E29E28B5739C0062B44F /* CIOPurchaseItem.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2266,7 +2266,7 @@
 				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchResultClickData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
-				BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */,
+				BF02E29F28B5739C0062B44F /* CIOPurchaseItem.swift in Sources */,
 				F638090B1F5E855B00C3B322 /* BoldAttributesProvider.swift in Sources */,
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,

--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		8DF2172D2888AE5E006384A5 /* CIOResultSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */; };
 		8DF2172F2888B56D006384A5 /* CIOResultSourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */; };
 		99D6877853DE657CAF7E876C /* Pods_UserApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D938EAC4478309F3008F3B0D /* Pods_UserApplication.framework */; };
-		BF02E29F28B5739C0062B44F /* CIOPurchaseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOPurchaseItem.swift */; };
+		BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOItem.swift */; };
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
@@ -371,7 +371,7 @@
 		8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSources.swift; sourceTree = "<group>"; };
 		8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSourceData.swift; sourceTree = "<group>"; };
 		A466AF5E4660C198B64CE5CE /* Pods-AutocompleteClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutocompleteClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutocompleteClientTests/Pods-AutocompleteClientTests.release.xcconfig"; sourceTree = "<group>"; };
-		BF02E29E28B5739C0062B44F /* CIOPurchaseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOPurchaseItem.swift; sourceTree = "<group>"; };
+		BF02E29E28B5739C0062B44F /* CIOItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOItem.swift; sourceTree = "<group>"; };
 		BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQuery.swift; sourceTree = "<group>"; };
 		BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsResponse.swift; sourceTree = "<group>"; };
 		BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsPod.swift; sourceTree = "<group>"; };
@@ -746,7 +746,7 @@
 				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
 				08FFB76D215EC1DF008CAA7D /* CIOTrackSearchSubmitData.swift */,
 				F685255C21414E1D00A27FAA /* CIOTrackSessionStartData.swift */,
-				BF02E29E28B5739C0062B44F /* CIOPurchaseItem.swift */,
+				BF02E29E28B5739C0062B44F /* CIOItem.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2266,7 +2266,7 @@
 				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchResultClickData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
-				BF02E29F28B5739C0062B44F /* CIOPurchaseItem.swift in Sources */,
+				BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */,
 				F638090B1F5E855B00C3B322 /* BoldAttributesProvider.swift in Sources */,
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,

--- a/AutocompleteClient.xcodeproj/project.pbxproj
+++ b/AutocompleteClient.xcodeproj/project.pbxproj
@@ -64,7 +64,6 @@
 		8DF2172D2888AE5E006384A5 /* CIOResultSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */; };
 		8DF2172F2888B56D006384A5 /* CIOResultSourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */; };
 		99D6877853DE657CAF7E876C /* Pods_UserApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D938EAC4478309F3008F3B0D /* Pods_UserApplication.framework */; };
-		BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF02E29E28B5739C0062B44F /* CIOItem.swift */; };
 		BF12196825D1F06200496189 /* CIORecommendationsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */; };
 		BF12196A25D1FD5700496189 /* CIORecommendationsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */; };
 		BF12196C25D1FDB300496189 /* CIORecommendationsPod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */; };
@@ -371,7 +370,6 @@
 		8DF2172C2888AE5E006384A5 /* CIOResultSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSources.swift; sourceTree = "<group>"; };
 		8DF2172E2888B56D006384A5 /* CIOResultSourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOResultSourceData.swift; sourceTree = "<group>"; };
 		A466AF5E4660C198B64CE5CE /* Pods-AutocompleteClientTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutocompleteClientTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutocompleteClientTests/Pods-AutocompleteClientTests.release.xcconfig"; sourceTree = "<group>"; };
-		BF02E29E28B5739C0062B44F /* CIOItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIOItem.swift; sourceTree = "<group>"; };
 		BF12196725D1F06200496189 /* CIORecommendationsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsQuery.swift; sourceTree = "<group>"; };
 		BF12196925D1FD5700496189 /* CIORecommendationsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsResponse.swift; sourceTree = "<group>"; };
 		BF12196B25D1FDB300496189 /* CIORecommendationsPod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIORecommendationsPod.swift; sourceTree = "<group>"; };
@@ -746,7 +744,6 @@
 				F6D2E9CB20E21022007F8761 /* CIOTrackSearchResultsLoadedData.swift */,
 				08FFB76D215EC1DF008CAA7D /* CIOTrackSearchSubmitData.swift */,
 				F685255C21414E1D00A27FAA /* CIOTrackSessionStartData.swift */,
-				BF02E29E28B5739C0062B44F /* CIOItem.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -2266,7 +2263,6 @@
 				F6DF7B9420849E8D00A7CDAD /* CIOTrackSearchResultClickData.swift in Sources */,
 				F69C2CA2207FADAD0060B2B9 /* CIOLogger.swift in Sources */,
 				F192DDEE1F5F123400114C8C /* RequestBuilder.swift in Sources */,
-				BF02E29F28B5739C0062B44F /* CIOItem.swift in Sources */,
 				F638090B1F5E855B00C3B322 /* BoldAttributesProvider.swift in Sources */,
 				088F7D26210FA43C005B9FB4 /* DateProvider.swift in Sources */,
 				F1F68DDD1F58B7D600B42602 /* Constants.swift in Sources */,

--- a/AutocompleteClient/FW/Logic/Request/CIOItem.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOItem.swift
@@ -1,5 +1,5 @@
 //
-//  CIOPurchaseItem.swift
+//  CIOItem.swift
 //  Constructor.io
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CIOPurchaseItem {
+public struct CIOItem {
     var customerID: String
     var variationID: String?
     var quantity: Int?

--- a/AutocompleteClient/FW/Logic/Request/CIOItem.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOItem.swift
@@ -1,0 +1,19 @@
+//
+//  CIOItem.swift
+//  Constructor.io
+//
+//  Copyright © Constructor.io. All rights reserved.
+//  http://constructor.io/
+//
+
+import Foundation
+
+public struct CIOItem {
+    var customerID: String
+    var variationID: String?
+    
+    public init(customerID: String, variationID: String? = nil) {
+        self.customerID = customerID
+        self.variationID = variationID
+    }
+}

--- a/AutocompleteClient/FW/Logic/Request/CIOItem.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOItem.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct CIOItem {
     var customerID: String
     var variationID: String?
-    
+
     public init(customerID: String, variationID: String? = nil) {
         self.customerID = customerID
         self.variationID = variationID

--- a/AutocompleteClient/FW/Logic/Request/CIOPurchaseItem.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOPurchaseItem.swift
@@ -1,5 +1,5 @@
 //
-//  CIOItem.swift
+//  CIOPurchaseItem.swift
 //  Constructor.io
 //
 //  Copyright © Constructor.io. All rights reserved.
@@ -8,12 +8,14 @@
 
 import Foundation
 
-public struct CIOItem {
+public struct CIOPurchaseItem {
     var customerID: String
     var variationID: String?
+    var quantity: Int?
 
-    public init(customerID: String, variationID: String? = nil) {
+    public init(customerID: String, variationID: String? = nil, quantity: Int? = nil) {
         self.customerID = customerID
         self.variationID = variationID
+        self.quantity = quantity
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
@@ -51,7 +51,7 @@ public struct CIOSearchQuery: CIORequestData {
      The list of hidden facet fields to return
      */
     public let hiddenFacets: [String]?
-    
+
     /**
      The variation map to use with the result set
      */

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
@@ -17,7 +17,7 @@ struct CIOTrackPurchaseData: CIORequestData {
     let revenue: Double?
     var sectionName: String?
     var orderID: String?
-    var items: [CIOPurchaseItem]?
+    var items: [CIOItem]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackPurchase.format, baseURL)
@@ -34,7 +34,7 @@ struct CIOTrackPurchaseData: CIORequestData {
         self.orderID = orderID
     }
 
-    init(items: [CIOPurchaseItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
+    init(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
         if items.count > 100 {
             self.items = Array(items[0 ..< 100])
         } else {

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
@@ -24,8 +24,7 @@ struct CIOTrackPurchaseData: CIORequestData {
     }
 
     init(customerIDs: [String], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
-        
-        if (customerIDs.count > 100) {
+        if customerIDs.count > 100 {
             self.customerIDs = Array(customerIDs[0 ..< 100])
         } else {
             self.customerIDs = customerIDs
@@ -35,10 +34,8 @@ struct CIOTrackPurchaseData: CIORequestData {
         self.orderID = orderID
     }
 
-    
     init(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
-        
-        if (items.count > 100) {
+        if items.count > 100 {
             self.items = Array(items[0 ..< 100])
         } else {
             self.items = items
@@ -65,18 +62,8 @@ struct CIOTrackPurchaseData: CIORequestData {
         }
 
         if let purchasedItems = self.items {
-            var items = [[String: String]]()
-
-            for item in purchasedItems {
-                var itemToAppend = ["item_id": item.customerID]
-
-                if (item.variationID != nil) {
-                    itemToAppend["variation_id"] = item.variationID
-                }
-
-                items.append(itemToAppend)
-            }
-            dict = ["items": items]
+            let items = purchasedItems.map { ["item_id": $0.customerID, "variation_id": $0.variationID] }
+            dict["items"] = items
         }
 
         if self.orderID != nil {

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
@@ -13,10 +13,11 @@ import Foundation
  */
 struct CIOTrackPurchaseData: CIORequestData {
 
-    let customerIDs: [String]
+    var customerIDs: [String]?
     let revenue: Double?
     var sectionName: String?
     var orderID: String?
+    var items: [CIOItem]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackPurchase.format, baseURL)
@@ -34,6 +35,19 @@ struct CIOTrackPurchaseData: CIORequestData {
         self.orderID = orderID
     }
 
+    
+    init(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
+        
+        if (items.count > 100) {
+            self.items = Array(items[0 ..< 100])
+        } else {
+            self.items = items
+        }
+        self.sectionName = sectionName
+        self.revenue = revenue
+        self.orderID = orderID
+    }
+
     func decorateRequest(requestBuilder: RequestBuilder) {
         requestBuilder.set(autocompleteSection: self.sectionName)
     }
@@ -43,8 +57,27 @@ struct CIOTrackPurchaseData: CIORequestData {
     }
 
     func httpBody(baseParams: [String: Any]) -> Data? {
-        let items = self.customerIDs.map { ["item_id": $0] }
-        var dict = ["items": items] as [String: Any]
+        var dict = [String: Any]()
+
+        if let purchasedCustomerIDs = self.customerIDs {
+            let items = purchasedCustomerIDs.map { ["item_id": $0] }
+            dict["items"] = items
+        }
+
+        if let purchasedItems = self.items {
+            var items = [[String: String]]()
+
+            for item in purchasedItems {
+                var itemToAppend = ["item_id": item.customerID]
+
+                if (item.variationID != nil) {
+                    itemToAppend["variation_id"] = item.variationID
+                }
+
+                items.append(itemToAppend)
+            }
+            dict = ["items": items]
+        }
 
         if self.orderID != nil {
             dict["order_id"] = self.orderID

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
@@ -17,7 +17,7 @@ struct CIOTrackPurchaseData: CIORequestData {
     let revenue: Double?
     var sectionName: String?
     var orderID: String?
-    var items: [CIOItem]?
+    var items: [CIOPurchaseItem]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackPurchase.format, baseURL)
@@ -34,7 +34,7 @@ struct CIOTrackPurchaseData: CIORequestData {
         self.orderID = orderID
     }
 
-    init(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
+    init(items: [CIOPurchaseItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil) {
         if items.count > 100 {
             self.items = Array(items[0 ..< 100])
         } else {
@@ -62,7 +62,17 @@ struct CIOTrackPurchaseData: CIORequestData {
         }
 
         if let purchasedItems = self.items {
-            let items = purchasedItems.map { ["item_id": $0.customerID, "variation_id": $0.variationID] }
+            var items = [[String: String]]()
+            purchasedItems.forEach { purchaseItem in
+                let quantity = purchaseItem.quantity ?? 1
+                for _ in 1...quantity {
+                    var item = ["item_id": purchaseItem.customerID]
+                    if let variation_id = purchaseItem.variationID {
+                        item["variation_id"] = variation_id
+                    }
+                    items.append(item)
+                }
+            }
             dict["items"] = items
         }
 

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -434,7 +434,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")
      ```
      */
-    public func trackPurchase(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackPurchase(items: [CIOPurchaseItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
         let data = CIOTrackPurchaseData(items: items, sectionName: section, revenue: revenue, orderID: orderID)
         let request = self.buildRequest(data: data)

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -419,6 +419,28 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         executeTracking(request, completionHandler: completionHandler)
     }
 
+    /**
+     Track when a user completes an order (usually fired on order confirmation page)
+
+     - Parameters:
+        - items: The items purchased
+        - revenue: The revenue of the purchase
+        - orderID: The order identifier
+        - sectionName The name of the autocomplete section the term came from (defaults to "products")
+        - completionHandler: The callback to execute on completion.
+     
+     ### Usage Example: ###
+     ```
+     constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")
+     ```
+     */
+    public func trackPurchase(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+        let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
+        let data = CIOTrackPurchaseData(items: items, sectionName: section, revenue: revenue, orderID: orderID)
+        let request = self.buildRequest(data: data)
+        executeTracking(request, completionHandler: completionHandler)
+    }
+
     private func trackSessionStart(session: Int, completionHandler: TrackingCompletionHandler? = nil) {
         let request = self.buildSessionStartRequest(session: session)
         executeTracking(request, completionHandler: completionHandler)

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -434,7 +434,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")
      ```
      */
-    public func trackPurchase(items: [CIOPurchaseItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackPurchase(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
         let data = CIOTrackPurchaseData(items: items, sectionName: section, revenue: revenue, orderID: orderID)
         let request = self.buildRequest(data: data)

--- a/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
@@ -90,7 +90,7 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
         XCTAssertEqual(payload?["order_id"] as? String, orderID)
     }
-    
+
     func testTrackPurchaseBuilder_WithLargeItemsArray() {
         let tracker = CIOTrackPurchaseData(customerIDs: Array(repeating: "itemID", count: 150), sectionName: self.sectionName, orderID: self.orderID)
         builder.build(trackData: tracker)
@@ -102,5 +102,25 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
         XCTAssertEqual(items.count, 100)
+    }
+
+    func testTrackPurchaseBuilder_WithItemsParam() {
+        let items = [
+            CIOItem(customerID: "custID1", variationID: "varID1"),
+            CIOItem(customerID: "custID2", variationID: "varID2"),
+            CIOItem(customerID: "custID3", variationID: "varID3")
+        ]
+        let tracker = CIOTrackPurchaseData(items: items, sectionName: self.sectionName, orderID: self.orderID)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let purchasedItems = payload?["items"] as? [[String: String]] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
+        XCTAssertEqual(purchasedItems.count, 3)
+        XCTAssertEqual(purchasedItems[0]["item_id"], items[0].customerID)
+        XCTAssertEqual(purchasedItems[0]["variation_id"], items[0].variationID)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
@@ -97,7 +97,7 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         let request = builder.getRequest()
         let url = request.url!.absoluteString
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
-        let items = payload?["items"] as? [[String:String]] ?? []
+        let items = payload?["items"] as? [[String: String]] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
@@ -106,9 +106,9 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
 
     func testTrackPurchaseBuilder_WithItemsParam() {
         let items = [
-            CIOItem(customerID: "custID1", variationID: "varID1"),
-            CIOItem(customerID: "custID2", variationID: "varID2"),
-            CIOItem(customerID: "custID3", variationID: "varID3")
+            CIOPurchaseItem(customerID: "custID1", variationID: "varID1"),
+            CIOPurchaseItem(customerID: "custID2", variationID: "varID2"),
+            CIOPurchaseItem(customerID: "custID3", variationID: "varID3")
         ]
         let tracker = CIOTrackPurchaseData(items: items, sectionName: self.sectionName, orderID: self.orderID)
         builder.build(trackData: tracker)
@@ -122,5 +122,28 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         XCTAssertEqual(purchasedItems.count, 3)
         XCTAssertEqual(purchasedItems[0]["item_id"], items[0].customerID)
         XCTAssertEqual(purchasedItems[0]["variation_id"], items[0].variationID)
+    }
+
+    func testTrackPurchaseBuilder_WithItemsContainingQuantityParam() {
+        let items = [
+            CIOPurchaseItem(customerID: "custID1", variationID: "varID1", quantity: 2),
+            CIOPurchaseItem(customerID: "custID2", variationID: "varID2", quantity: 3)
+        ]
+        let tracker = CIOTrackPurchaseData(items: items, sectionName: self.sectionName, orderID: self.orderID)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let purchasedItems = payload?["items"] as? [[String: String]] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
+        XCTAssertEqual(purchasedItems.count, 5)
+        XCTAssertEqual(purchasedItems[0]["item_id"], items[0].customerID)
+        XCTAssertEqual(purchasedItems[0]["variation_id"], items[0].variationID)
+        XCTAssertEqual(purchasedItems[1]["item_id"], items[0].customerID)
+        XCTAssertEqual(purchasedItems[1]["variation_id"], items[0].variationID)
+        XCTAssertEqual(purchasedItems[2]["item_id"], items[1].customerID)
+        XCTAssertEqual(purchasedItems[2]["variation_id"], items[1].variationID)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
@@ -106,9 +106,9 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
 
     func testTrackPurchaseBuilder_WithItemsParam() {
         let items = [
-            CIOPurchaseItem(customerID: "custID1", variationID: "varID1"),
-            CIOPurchaseItem(customerID: "custID2", variationID: "varID2"),
-            CIOPurchaseItem(customerID: "custID3", variationID: "varID3")
+            CIOItem(customerID: "custID1", variationID: "varID1"),
+            CIOItem(customerID: "custID2", variationID: "varID2"),
+            CIOItem(customerID: "custID3", variationID: "varID3")
         ]
         let tracker = CIOTrackPurchaseData(items: items, sectionName: self.sectionName, orderID: self.orderID)
         builder.build(trackData: tracker)
@@ -126,8 +126,8 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
 
     func testTrackPurchaseBuilder_WithItemsContainingQuantityParam() {
         let items = [
-            CIOPurchaseItem(customerID: "custID1", variationID: "varID1", quantity: 2),
-            CIOPurchaseItem(customerID: "custID2", variationID: "varID2", quantity: 3)
+            CIOItem(customerID: "custID1", variationID: "varID1", quantity: 2),
+            CIOItem(customerID: "custID2", variationID: "varID2", quantity: 3)
         ]
         let tracker = CIOTrackPurchaseData(items: items, sectionName: self.sectionName, orderID: self.orderID)
         builder.build(trackData: tracker)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -187,6 +187,21 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
+    func testPurchase_WithVariationIDs() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
+        let expectation = XCTestExpectation(description: "Tracking 204")
+        let items = [
+            CIOItem(customerID: "10001", variationID: "20001"),
+            CIOItem(customerID: "luistrenker-jacket-K245511299-cream", variationID: "M0E20000000E2ZJ")
+        ]
+        constructorClient.trackPurchase(items: items, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
     func testRecommendations() {
         let expectation = XCTestExpectation(description: "Request 204")
         let query = CIORecommendationsQuery(podID: podID, itemID: customerID, section: sectionName)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -191,8 +191,22 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Tracking 204")
         let items = [
-            CIOItem(customerID: "10001", variationID: "20001"),
-            CIOItem(customerID: "luistrenker-jacket-K245511299-cream", variationID: "M0E20000000E2ZJ")
+            CIOPurchaseItem(customerID: "10001", variationID: "20001"),
+            CIOPurchaseItem(customerID: "luistrenker-jacket-K245511299-cream", variationID: "M0E20000000E2ZJ")
+        ]
+        constructorClient.trackPurchase(items: items, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
+            let cioError = response.error as? CIOError
+            XCTAssertNil(cioError)
+            expectation.fulfill()
+        })
+        self.wait(for: expectation)
+    }
+
+    func testPurchase_WithQuantity() {
+        let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
+        let expectation = XCTestExpectation(description: "Tracking 204")
+        let items = [
+            CIOPurchaseItem(customerID: "10001", variationID: "20001", quantity: 2)
         ]
         constructorClient.trackPurchase(items: items, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
             let cioError = response.error as? CIOError

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -191,8 +191,8 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Tracking 204")
         let items = [
-            CIOPurchaseItem(customerID: "10001", variationID: "20001"),
-            CIOPurchaseItem(customerID: "luistrenker-jacket-K245511299-cream", variationID: "M0E20000000E2ZJ")
+            CIOItem(customerID: "10001", variationID: "20001"),
+            CIOItem(customerID: "luistrenker-jacket-K245511299-cream", variationID: "M0E20000000E2ZJ")
         ]
         constructorClient.trackPurchase(items: items, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
             let cioError = response.error as? CIOError
@@ -206,7 +206,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Tracking 204")
         let items = [
-            CIOPurchaseItem(customerID: "10001", variationID: "20001", quantity: 2)
+            CIOItem(customerID: "10001", variationID: "20001", quantity: 2)
         ]
         constructorClient.trackPurchase(items: items, sectionName: sectionName, revenue: revenue, orderID: orderID, completionHandler: { response in
             let cioError = response.error as? CIOError

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1
 // Track when items are purchased
 constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")
 
-// New way to track when items are purchased (supported in v2.5.5 and above)
+// Tracking items w/ variations in purchases (supported in v2.5.5 and above)
 let purchaseItems = [
   CIOItem(customerID: "custID1", variationID: "varID1", quantity: 2),
   CIOItem(customerID: "custID2", variationID: "varID2", quantity: 3)

--- a/README.md
+++ b/README.md
@@ -216,4 +216,11 @@ constructorIO.trackConversion(itemName: "Fashionable Toothpicks", customerID: "1
 
 // Track when items are purchased
 constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, orderID: "343-315")
+
+// New way to track when items are purchased (supported in v2.5.5 and above)
+let purchaseItems = [
+  CIOPurchaseItem(customerID: "custID1", variationID: "varID1", quantity: 2),
+  CIOPurchaseItem(customerID: "custID2", variationID: "varID2", quantity: 3)
+]
+constructorIO.trackPurchase(items: purchaseItems, revenue: 93.89, orderID: "423-2432")
 ```

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ constructorIO.trackPurchase(customerIDs: ["123-AB", "456-CD"], revenue: 34.49, o
 
 // New way to track when items are purchased (supported in v2.5.5 and above)
 let purchaseItems = [
-  CIOPurchaseItem(customerID: "custID1", variationID: "varID1", quantity: 2),
-  CIOPurchaseItem(customerID: "custID2", variationID: "varID2", quantity: 3)
+  CIOItem(customerID: "custID1", variationID: "varID1", quantity: 2),
+  CIOItem(customerID: "custID2", variationID: "varID2", quantity: 3)
 ]
 constructorIO.trackPurchase(items: purchaseItems, revenue: 93.89, orderID: "423-2432")
 ```


### PR DESCRIPTION
### Updates:
* Add new `CIOItem` struct
* Overloaded `trackPurchase` function to accept a list of `CIOItem`s
* Overloaded `trackPurchaseData`'s init function to accept a list of `CIOItem`s
    * Changing `customerIDs` and `items` fields to be optional so you can pass either isn't super great. Makes it possible to send purchase events w/o items
* Add support for quantity
* Add/update tests (all tests pass)