### PR TITLE
[CSL-2352] Update query items logic.

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
@@ -66,8 +66,19 @@ struct QueryItemCollection {
         var dict: [String: Any] = [:]
         flattenedArray.forEach { item in
             if item.value != nil {
-                dict[item.name] = item.value
+                if let value = dict[item.name] {
+                    if var arrayValue = value as? [String] {
+                        arrayValue.append(item.value!)
+                    } else {
+                        dict[item.name] = [value, item.value!]
+                    }
+                } else {
+                    dict[item.name] = item.value
+                }
             }
+        }
+        if let usValue = dict["us"] as? String {
+            dict["us"] = [usValue]
         }
         // swiftlint:disable force_cast
         if dict["s"] != nil {

--- a/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
@@ -66,20 +66,11 @@ struct QueryItemCollection {
         var dict: [String: Any] = [:]
         flattenedArray.forEach { item in
             if item.value != nil {
-                if let value = dict[item.name] {
-                    if var arrayValue = value as? [String] {
-                        arrayValue.append(item.value!)
-                    } else {
-                        dict[item.name] = [value, item.value!]
-                    }
-                } else {
-                    dict[item.name] = item.value
-                }
+                dict[item.name] = item.value
             }
         }
-        if let usValue = dict["us"] as? String {
-            dict["us"] = [usValue]
-        }
+        dict["us"] = nil
+        print(dict)
         // swiftlint:disable force_cast
         if dict["s"] != nil {
             dict["s"] = Int64(dict["s"] as! String)

--- a/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/QueryItemCollection.swift
@@ -70,7 +70,6 @@ struct QueryItemCollection {
             }
         }
         dict["us"] = nil
-        print(dict)
         // swiftlint:disable force_cast
         if dict["s"] != nil {
             dict["s"] = Int64(dict["s"] as! String)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -41,7 +41,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        self.constructor = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
+        self.constructor = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey, segments: ["123", "234"]))
     }
 
     override func tearDown() {


### PR DESCRIPTION
Deleting the "us" parameter from http body. 

Api expects the format as a list, but our logic right now doesn't handle that. 

Instead of changing the logic, I am removing the "us" parameter from the httpbody.