### PR TITLE
[CSL-2362] Rounds revenue to 2dp in purchase tracking event

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
@@ -52,6 +52,10 @@ struct CIOTrackPurchaseData: CIORequestData {
     func httpMethod() -> String {
         return "POST"
     }
+    
+    func roundTo2dp(num: Double) -> Double {
+        return (num * 100).rounded() / 100
+    }
 
     func httpBody(baseParams: [String: Any]) -> Data? {
         var dict = [String: Any]()
@@ -81,7 +85,7 @@ struct CIOTrackPurchaseData: CIORequestData {
         }
 
         if self.revenue != nil {
-            dict["revenue"] = self.revenue
+            dict["revenue"] = self.roundTo2dp(num: self.revenue!)
         }
 
         dict["beacon"] = true

--- a/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
@@ -78,6 +78,18 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
         XCTAssertEqual(payload?["revenue"] as? Double, revenue)
     }
+    
+    func testTrackPurchaseBuilder_WithFloatingPointRevenue() {
+        let tracker = CIOTrackPurchaseData(customerIDs: self.customerIDs, sectionName: self.sectionName, revenue: 12.345678)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
+        XCTAssertEqual(payload?["revenue"] as? Double, 12.35, "Incorrect rounding of floating point revenue.")
+    }
 
     func testTrackPurchaseBuilder_WithOrderID() {
         let tracker = CIOTrackPurchaseData(customerIDs: self.customerIDs, sectionName: self.sectionName, orderID: self.orderID)


### PR DESCRIPTION
When creating the HTTP Body to be used for the Purchase Tracking Event, round the revenue down to 2 decimal places.