### PR TITLE
[NOCSL] Don't send empty test cell

### DIFF
--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -583,7 +583,9 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
     private func attachABTestCells(requestBuilder: RequestBuilder) {
         self.config.testCells?.forEach({ [unowned requestBuilder] cell in
-            requestBuilder.set(testCellKey: cell.key, testCellValue: cell.value)
+            if (!cell.key.isEmpty) {
+                requestBuilder.set(testCellKey: cell.key, testCellValue: cell.value)
+            }
         })
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOABTestCellTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOABTestCellTests.swift
@@ -48,4 +48,15 @@ class ConstructorIOABTestCellTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testTrackInputFocus_WithEmptyTestCellName() {
+        let config = ConstructorIOConfig(apiKey: "key_OucJxxrfiTVUQx0C", testCells: [
+            CIOABTestCell(key: "", value: "there")
+        ])
+        let constructor = TestConstants.testConstructor(config)
+        let searchTerm = "corn"
+        let builder = CIOBuilder(expectation: "Calling trackInputFocus should send a valid request without test cells", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/behavior?_dt=\(kRegexTimestamp)&action=focus&c=\(kRegexVersion)&i=\(kRegexClientID)&key=key_OucJxxrfiTVUQx0C&s=\(kRegexSession)&term=corn"), builder.create())
+        constructor.trackInputFocus(searchTerm: searchTerm)
+        self.wait(for: builder.expectation)
+    }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOABTestCellTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOABTestCellTests.swift
@@ -59,4 +59,16 @@ class ConstructorIOABTestCellTests: XCTestCase {
         constructor.trackInputFocus(searchTerm: searchTerm)
         self.wait(for: builder.expectation)
     }
+    
+    func testTrackInputFocus_WithEmptyTestCellValue() {
+        let config = ConstructorIOConfig(apiKey: "key_OucJxxrfiTVUQx0C", testCells: [
+            CIOABTestCell(key: "hi", value: "")
+        ])
+        let constructor = TestConstants.testConstructor(config)
+        let searchTerm = "corn"
+        let builder = CIOBuilder(expectation: "Calling trackInputFocus should send a valid request without test cells", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/behavior?_dt=\(kRegexTimestamp)&action=focus&c=\(kRegexVersion)&ef-hi=&i=\(kRegexClientID)&key=key_OucJxxrfiTVUQx0C&s=\(kRegexSession)&term=corn"), builder.create())
+        constructor.trackInputFocus(searchTerm: searchTerm)
+        self.wait(for: builder.expectation)
+    }
 }


### PR DESCRIPTION
Empty test cell values will cause the api to throw 400. This prevent those empty values from being sent. 