### PR TITLE
Fix lint errors

### DIFF
--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -119,12 +119,12 @@ struct Constants {
         static let defaultPage = 1
         static let defaultPerPage = 30
     }
-    
+
     struct BrowseGroupsQuery {
         static let format = "%@/browse/groups"
         static let defaultSectionName = "Products"
     }
-    
+
     struct BrowseFacetsQuery {
         static let format = "%@/browse/facets"
         static let page = "page"
@@ -232,7 +232,7 @@ struct Constants {
     struct TrackBrowseResultClick {
         static let format = "%@/v2/behavioral_action/browse_result_click"
     }
-    
+
     struct TrackItemDetailLoad {
         static let format = "%@/v2/behavioral_action/item_detail_load"
     }

--- a/AutocompleteClient/FW/API/Parser/Browse/BrowseResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Browse/BrowseResponseParser.swift
@@ -33,7 +33,7 @@ class BrowseResponseParser: AbstractBrowseResponseParser {
             let resultID = json?["result_id"] as? String ?? ""
             let resultSources: CIOResultSources? = CIOResultSources(json: response["result_sources"] as? JSONObject)
             let refinedContent: [CIORefinedContent] = refinedContentObj?.compactMap({ obj in return CIORefinedContent(json: obj) }) ?? []
-            
+
             guard let request: JSONObject = json?["request"] as? JSONObject else {
                 throw CIOError(errorType: .invalidResponse)
             }

--- a/AutocompleteClient/FW/API/Parser/Quizzes/QuizResultsResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Quizzes/QuizResultsResponseParser.swift
@@ -13,7 +13,7 @@ class QuizResultsResponseParser: AbstractQuizResultsResponseParser {
 
         do {
             let json = try JSONSerialization.jsonObject(with: quizResultsResponseData) as? JSONObject
-            
+
             guard let response = json?["response"] as? JSONObject else {
                 throw CIOError(errorType: .invalidResponse)
             }
@@ -29,7 +29,7 @@ class QuizResultsResponseParser: AbstractQuizResultsResponseParser {
             let groups: [CIOFilterGroup] = groupsObj?.compactMap({ obj  in return CIOFilterGroup(json: obj) }) ?? []
             let totalNumResults = response["total_num_results"] as? Int ?? 0
             let resultSources: CIOResultSources? = CIOResultSources(json: response["result_sources"] as? JSONObject)
-            
+
             let resultID = json?["result_id"] as? String ?? ""
             let quizVersionId = json?["quiz_version_id"] as? String ?? ""
             let quizId = json?["quiz_id"] as? String ?? ""

--- a/AutocompleteClient/FW/API/Parser/Search/SearchResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Search/SearchResponseParser.swift
@@ -32,7 +32,7 @@ class SearchResponseParser: AbstractSearchResponseParser {
             let resultID = json?["result_id"] as? String ?? ""
             let resultSources: CIOResultSources? = CIOResultSources(json: response["result_sources"] as? JSONObject)
             let refinedContent: [CIORefinedContent] = refinedContentObj?.compactMap({ obj in return CIORefinedContent(json: obj) }) ?? []
-            
+
             guard let request: JSONObject = json?["request"] as? JSONObject else {
                 throw CIOError(errorType: .invalidResponse)
             }

--- a/AutocompleteClient/FW/DependencyInjection/DependencyContainer.swift
+++ b/AutocompleteClient/FW/DependencyInjection/DependencyContainer.swift
@@ -29,7 +29,7 @@ class DependencyContainer {
     var browseResponseParser: () -> AbstractBrowseResponseParser = {
         return BrowseResponseParser()
     }
-    
+
     var browseFacetsResponseParser: () -> AbstractBrowseFacetsResponseParser = {
         return BrowseFacetsResponseParser()
     }
@@ -37,15 +37,15 @@ class DependencyContainer {
     var browseFacetOptionsResponseParser: () -> AbstractBrowseFacetOptionsResponseParser = {
         return BrowseFacetOptionsResponseParser()
     }
-    
+
     var recommendationsResponseParser: () -> AbstractRecommendationsResponseParser = {
         return RecommendationsResponseParser()
     }
-    
+
     var quizQuestionResponseParser: () -> AbstractQuizQuestionResponseParser = {
         return QuizQuestionResponseParser()
     }
-    
+
     var quizResultsResponseParser: () -> AbstractQuizResultsResponseParser = {
         return QuizResultsResponseParser()
     }

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseFacetOptionsQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseFacetOptionsQueryBuilder.swift
@@ -12,12 +12,12 @@ import Foundation
  Request builder for creating an browse facet options query.
  */
 public class CIOBrowseFacetOptionsQueryBuilder {
-    
+
     /**
      The name of the facet whose options to return
      */
     var facetName: String
-    
+
     /**
      Whether or not to return hidden facets
      */
@@ -29,7 +29,7 @@ public class CIOBrowseFacetOptionsQueryBuilder {
     public init(facetName: String) {
         self.facetName = facetName
     }
-    
+
     /**
      Add a bool indicating whether or not to return hidden facets
      */

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseFacetsQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseFacetsQueryBuilder.swift
@@ -12,7 +12,7 @@ import Foundation
  Request builder for creating an browse facets query.
  */
 public class CIOBrowseFacetsQueryBuilder {
-    
+
     /**
      The page of results to request (can't be used with offset)
      */
@@ -22,7 +22,7 @@ public class CIOBrowseFacetsQueryBuilder {
      The offset of results to request (can't be used with page)
      */
     var offset: Int?
-    
+
     /**
      The number of results per page to return
      */
@@ -62,7 +62,6 @@ public class CIOBrowseFacetsQueryBuilder {
         self.showHiddenFacets = showHiddenFacets
         return self
     }
-
 
     /**
      Add a offset of results to return

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseGroupsQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseGroupsQueryBuilder.swift
@@ -12,7 +12,7 @@ import Foundation
  Request builder for creating an browse groups query.
  */
 public class CIOBrowseGroupsQueryBuilder {
-    
+
     /**
      The id of the specific group that should be included in the response
      */
@@ -40,7 +40,7 @@ public class CIOBrowseGroupsQueryBuilder {
         self.groupId = groupId
         return self
     }
-    
+
     /**
      Specify the maximum depth of the hierarchy that should be included in the response
      Defaults to 1 if unspecified
@@ -49,7 +49,7 @@ public class CIOBrowseGroupsQueryBuilder {
         self.groupsMaxDepth = maxDepth
         return self
     }
-    
+
     /**
      Specify the section to return results from
      */

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
@@ -67,7 +67,7 @@ public class CIOBrowseQueryBuilder {
      The sort method/order for groups
      */
     var groupsSortOption: CIOGroupsSortOption?
-    
+
     /**
      The pre filter expression used to refine results.
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.io/rest_api/collections/#add-items-dynamically
@@ -157,7 +157,7 @@ public class CIOBrowseQueryBuilder {
         self.groupsSortOption = groupsSortOption
         return self
     }
-    
+
     /**
      Add the pre filter expression
      */

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
@@ -62,7 +62,7 @@ public class CIOSearchQueryBuilder {
      The sort method/order for groups
      */
     var groupsSortOption: CIOGroupsSortOption?
-    
+
     /**
      The pre filter expression used to refine results
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.io/rest_api/collections/#add-items-dynamically
@@ -142,7 +142,7 @@ public class CIOSearchQueryBuilder {
         self.groupsSortOption = groupsSortOption
         return self
     }
-    
+
     /**
      Add the pre filter expression
      */

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -68,7 +68,7 @@ extension RequestBuilder {
     func set(searchSection: String) {
         queryItems.add(URLQueryItem(name: Constants.SearchQuery.section, value: searchSection))
     }
-    
+
     func set(section: String) {
         queryItems.add(URLQueryItem(name: Constants.Query.section, value: section))
     }
@@ -105,7 +105,7 @@ extension RequestBuilder {
         let offsetString = String(offset)
         queryItems.add(URLQueryItem(name: Constants.BrowseFacetsQuery.offset, value: offsetString))
     }
-    
+
     func set(perPage: Int) {
         let perPageString = String(perPage)
         queryItems.add(URLQueryItem(name: Constants.SearchQuery.perPage, value: perPageString))
@@ -173,12 +173,12 @@ extension RequestBuilder {
         guard let hiddenFacet = hiddenFacet else { return }
         self.set(fmtOption: (key: "hidden_facets", value: hiddenFacet))
     }
-    
+
     func set(showHiddenFacets: Bool) {
         let showHiddenFacetsString = String(showHiddenFacets)
         queryItems.add(URLQueryItem(name: Constants.BrowseFacetsQuery.showHiddenFacets, value: showHiddenFacetsString))
     }
-    
+
     func set(facetName: String?) {
         guard let facetName = facetName else { return }
         let facetNameString = String(facetName)
@@ -207,7 +207,7 @@ extension RequestBuilder {
             // Do nothing
         }
     }
-    
+
     func set(preFilterExpression: String?) {
         guard let preFilterExpression = preFilterExpression else { return }
         queryItems.add(URLQueryItem(name: "pre_filter_expression", value: preFilterExpression))
@@ -230,7 +230,7 @@ extension RequestBuilder {
         guard let itemId = id else { return }
         queryItems.add(URLQueryItem(name: "ids", value: itemId))
     }
-    
+
     func set(answer: [String]?) {
         guard let answer = answer else { return }
         queryItems.add(URLQueryItem(name: Constants.Quiz.answers, value: answer.joined(separator: ",")))
@@ -247,7 +247,7 @@ extension RequestBuilder {
         guard let quizVersionId = quizVersionId else { return }
         queryItems.add(URLQueryItem(name: Constants.Quiz.quizVersionId, value: quizVersionId))
     }
-    
+
     func set(quizSessionId: String?) {
         guard let quizSessionId = quizSessionId else { return }
         queryItems.add(URLQueryItem(name: Constants.Quiz.quizSessionId, value: quizSessionId))

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder.swift
@@ -70,10 +70,10 @@ class RequestBuilder {
         // TODO: Do not force unwrap trackData here;
         let urlString = self.trackData!.url(with: self.baseURL)
         let ignoreDtPaths = [
-            String(format: Constants.BrowseGroupsQuery.format, ""), 
-            String(format: Constants.BrowseFacetsQuery.format, ""), 
+            String(format: Constants.BrowseGroupsQuery.format, ""),
+            String(format: Constants.BrowseFacetsQuery.format, ""),
             String(format: Constants.BrowseFacetOptionsQuery.format, "")
-        ];
+        ]
 
         var urlComponents = URLComponents(string: urlString)!
 
@@ -88,7 +88,7 @@ class RequestBuilder {
         if (!ignoreDtPaths.contains { urlString.contains($0) }) {
             self.addDateQueryItem(queryItems: &allQueryItems)
         }
-        
+
         // attach `action` if necessary from base url
         if urlComponents.queryItems != nil {
             allQueryItems.add((urlComponents.queryItems?.first)!)

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseFacetsQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseFacetsQuery.swift
@@ -21,7 +21,7 @@ public struct CIOBrowseFacetsQuery: CIORequestData {
      The offset of results to request (can't be used with page)
      */
     public let offset: Int?
-    
+
     /**
      The number of results per page to return
      */

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseGroupsQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseGroupsQuery.swift
@@ -12,7 +12,7 @@ import Foundation
  Struct encapsulating the necessary and additional parameters required to execute a browse groups query.
  */
 public struct CIOBrowseGroupsQuery: CIORequestData {
-    
+
     /**
      The id of the specific group that should be included in the response
      */
@@ -22,7 +22,7 @@ public struct CIOBrowseGroupsQuery: CIORequestData {
      The section to return results from
      */
     public let section: String
-    
+
     /**
      The maximum depth of the hierarchy, in case of hierarchical groups, that should be included in the response
      */

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
@@ -67,7 +67,7 @@ public struct CIOBrowseQuery: CIORequestData {
      The sort method/order for groups
      */
     public let groupsSortOption: CIOGroupsSortOption?
-    
+
     /**
      The pre filter expression used to refine results
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.io/rest_api/collections/#add-items-dynamically

--- a/AutocompleteClient/FW/Logic/Request/CIOQuizQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOQuizQuery.swift
@@ -27,7 +27,7 @@ public struct CIOQuizQuery: CIORequestData {
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
      */
     public var quizVersionId: String?
-    
+
     /**
      Unique quiz_session_id for the quiz.
      The quiz session id will be returned with the first request and it should be passed with subsequent requests.

--- a/AutocompleteClient/FW/Logic/Request/CIORequestData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIORequestData.swift
@@ -13,7 +13,7 @@ protocol CIORequestData {
     func decorateRequest(requestBuilder: RequestBuilder)
 
     func url(with baseURL: String) -> String
-    
+
     func urlWithFormat(baseURL: String, format: String) -> String
 
     func queryItems(baseItems: [URLQueryItem]) -> [URLQueryItem]

--- a/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
@@ -62,7 +62,7 @@ public struct CIOSearchQuery: CIORequestData {
      The sort method/order for groups
      */
     public let groupsSortOption: CIOGroupsSortOption?
-    
+
     /**
      The pre filter expression used to refine results
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.io/rest_api/collections/#add-items-dynamically

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackItemDetailLoadData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackItemDetailLoadData.swift
@@ -18,7 +18,6 @@ struct CIOTrackItemDetailLoadData: CIORequestData {
     let sectionName: String?
     let variationID: String?
     let url: String
-    
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackItemDetailLoad.format, baseURL)
@@ -42,7 +41,7 @@ struct CIOTrackItemDetailLoadData: CIORequestData {
         var dict = [
             "item_name": self.itemName,
             "item_id": self.customerID,
-            "url": self.url,
+            "url": self.url
         ] as [String: Any]
 
         if self.variationID != nil {

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackPurchaseData.swift
@@ -52,7 +52,7 @@ struct CIOTrackPurchaseData: CIORequestData {
     func httpMethod() -> String {
         return "POST"
     }
-    
+
     func roundTo2dp(num: Double) -> Double {
         return (num * 100).rounded() / 100
     }

--- a/AutocompleteClient/FW/Logic/Result/CIOFilterGroup.swift
+++ b/AutocompleteClient/FW/Logic/Result/CIOFilterGroup.swift
@@ -37,7 +37,7 @@ public class CIOFilterGroup: NSObject {
      List of parent groups that it belongs to
      */
     public let parents: [CIOFilterGroup]
-    
+
     /**
      JSON object with custom metadata attached with the item group.
      */

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOBrowseResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOBrowseResponse.swift
@@ -56,7 +56,7 @@ public struct CIOBrowseResponse {
      Sources of the result set
      */
     public let resultSources: CIOResultSources?
-    
+
     /**
      Request object used to retrieve the Browse Response
      */

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizQuestionResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizQuestionResponse.swift
@@ -23,7 +23,7 @@ public struct CIOQuizQuestionResponse {
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
      */
     public let quizVersionId: String
-    
+
     /**
      Unique quiz_session_id for the quiz.
      The quiz session id will be returned with the first request and it should be passed with subsequent requests.

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizResultsResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizResultsResponse.swift
@@ -31,36 +31,36 @@ public struct CIOQuizResultsResponse {
      List of sorting options
      */
     public let sortOptions: [CIOSortOption]
-    
+
     /**
      Total number of results for the result
      */
     public let totalNumResults: Int
-    
+
     /**
      Sources of the result set
      */
     public let resultSources: CIOResultSources?
-    
+
     /**
      Result ID of the result set returned
      */
     public let resultID: String
-    
+
     /**
      Unique quiz_version_id for the quiz.
      The quiz version id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
      */
     public let quizVersionId: String
-    
+
     /**
      Unique quiz_session_id for the quiz.
      The quiz session id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-sessions
      */
     public let quizSessionId: String
-    
+
     /**
      Id of the quiz
      */

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOSearchResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOSearchResponse.swift
@@ -63,7 +63,7 @@ public struct CIOSearchResponse {
     public var isRedirect: Bool {
         return self.redirectInfo != nil
     }
-    
+
     /**
      Request object used to retrieve the Search Response
      */

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -18,6 +18,8 @@ public typealias TrackingCompletionHandler = (TrackingTaskResponse) -> Void
 public typealias QuizQuestionQueryCompletionHandler = (QuizQuestionTaskResponse) -> Void
 public typealias QuizResultsQueryCompletionHandler = (QuizResultsTaskResponse) -> Void
 
+// swiftlint:disable type_body_length file_length
+
 /**
  The main class to be used for getting autocomplete results and tracking behavioural data.
  */
@@ -930,3 +932,4 @@ public class ConstructorIO: CIOSessionManagerDelegate {
     }
 
 }
+// swiftlint:enable type_body_length file_length

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -590,7 +590,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
-    
+
     /**
      Track when a user views a product detail page
 
@@ -659,7 +659,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
     private func attachABTestCells(requestBuilder: RequestBuilder) {
         self.config.testCells?.forEach({ [unowned requestBuilder] cell in
-            if (!cell.key.isEmpty) {
+            if !cell.key.isEmpty {
                 requestBuilder.set(testCellKey: cell.key, testCellValue: cell.value)
             }
         })
@@ -782,7 +782,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
             }
         }
     }
-    
+
     private func executeBrowseFacetOptions(_ request: URLRequest, completionHandler: @escaping BrowseFacetOptionsQueryCompletionHandler) {
         let dispatchHandlerOnMainQueue = { response in
             DispatchQueue.main.async {
@@ -805,7 +805,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
             }
         }
     }
-    
+
     private func executeRecommendations(_ request: URLRequest, completionHandler: @escaping RecommendationsQueryCompletionHandler) {
         let dispatchHandlerOnMainQueue = { response in
             DispatchQueue.main.async {
@@ -904,11 +904,11 @@ public class ConstructorIO: CIOSessionManagerDelegate {
     private func parseBrowse(_ browseResponseData: Data) throws -> CIOBrowseResponse {
         return try self.browseParser.parse(browseResponseData: browseResponseData)
     }
-    
+
     private func parseBrowseFacets(_ browseFacetsResponseData: Data) throws -> CIOBrowseFacetsResponse {
         return try self.browseFacetsParser.parse(browseFacetsResponseData: browseFacetsResponseData)
     }
-    
+
     private func parseBrowseFacetOptions(_ browseFacetOptionsResponseData: Data) throws -> CIOBrowseFacetOptionsResponse {
         return try self.browseFacetOptionsParser.parse(browseFacetOptionsResponseData: browseFacetOptionsResponseData)
     }

--- a/AutocompleteClientTests/FW/API/Parser/BrowseResponseParserTest.swift
+++ b/AutocompleteClientTests/FW/API/Parser/BrowseResponseParserTest.swift
@@ -23,13 +23,13 @@ class BrowseResponseParserTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testBrowseParser_parsingRequestObjectAsJson_hasRelevantFields() {
         let data = TestResource.load(name: TestResource.Response.browseJSONFilename)
         do {
             let response = try self.parser.parse(browseResponseData: data)
             let requestJson = response.request
-            
+
             let fmtOptions = requestJson["fmt_options"] as? JSONObject
             let groupsMaxDepth = fmtOptions?["groups_max_depth"]
             let groupsStart = fmtOptions?["groups_start"]
@@ -48,12 +48,12 @@ class BrowseResponseParserTests: XCTestCase {
             XCTAssertNotNil(requestJson["features"], "Valid features should be correctly parsed")
             XCTAssertNotNil(requestJson["feature_variants"], "Valid featureVariants should be correctly parsed")
             XCTAssertNotNil(requestJson["searchandized_items"], "Valid searchandizedItems should be correctly parsed")
-            
+
         } catch {
             XCTFail("Parse should never throw an exception when a valid JSON string is passed.")
         }
     }
-    
+
     func testBrowseParser_ParsingJSONString_ParsesRefinedContent() {
         let data = TestResource.load(name: TestResource.Response.browseJSONFilename)
         do {

--- a/AutocompleteClientTests/FW/API/Parser/SearchResponseParserTests.swift
+++ b/AutocompleteClientTests/FW/API/Parser/SearchResponseParserTests.swift
@@ -172,13 +172,13 @@ class SearchResponseParserTests: XCTestCase {
             XCTFail("Parse should never throw an exception when a valid JSON string is passed.")
         }
     }
-    
+
     func testSearchParser_parsingRequestObjectAsJson_hasRelevantFields() {
         let data = TestResource.load(name: TestResource.Response.searchJSONFilename)
         do {
             let response = try self.parser.parse(searchResponseData: data)
             let requestJson = response.request
-            
+
             let fmtOptions = requestJson["fmt_options"] as? JSONObject
             let groupsMaxDepth = fmtOptions?["groups_max_depth"]
             let groupsStart = fmtOptions?["groups_start"]
@@ -208,7 +208,7 @@ class SearchResponseParserTests: XCTestCase {
             XCTAssertNotNil(facetData, "Valid data object should be correctly parsed")
             XCTAssertEqual(facetData?["url"] as? String, "example.com", "Valid data url value should be correctly parsed")
 
-            XCTAssertEqual(response.facets.first?.hidden, true , "Valid hidden value should be correctly parsed")
+            XCTAssertEqual(response.facets.first?.hidden, true, "Valid hidden value should be correctly parsed")
         } catch {
             XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
         }

--- a/AutocompleteClientTests/FW/Logic/Request/QuizzesQueryRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/QuizzesQueryRequestBuilderTests.swift
@@ -6,8 +6,8 @@
 //  http://constructor.io/
 //
 
-import XCTest
 @testable import ConstructorAutocomplete
+import XCTest
 
 class QuizzesQueryRequestBuilderTests: XCTestCase {
     fileprivate let quizId: String = "1"

--- a/AutocompleteClientTests/FW/Logic/Request/TrackItemDetailLoadRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackItemDetailLoadRequestBuilder.swift
@@ -6,8 +6,8 @@
 //  http://constructor.io/
 //
 
-import XCTest
 @testable import ConstructorAutocomplete
+import XCTest
 
 class TrackItemDetailLoadRequestBuilderTests: XCTestCase {
 

--- a/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackPurchaseRequestBuilderTests.swift
@@ -78,7 +78,7 @@ class TrackPurchaseRequestBuilderTests: XCTestCase {
         XCTAssertTrue(url.hasPrefix("https://ac.cnstrc.com/v2/behavioral_action/purchase?"))
         XCTAssertEqual(payload?["revenue"] as? Double, revenue)
     }
-    
+
     func testTrackPurchaseBuilder_WithFloatingPointRevenue() {
         let tracker = CIOTrackPurchaseData(customerIDs: self.customerIDs, sectionName: self.sectionName, revenue: 12.345678)
         builder.build(trackData: tracker)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOABTestCellTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOABTestCellTests.swift
@@ -59,7 +59,7 @@ class ConstructorIOABTestCellTests: XCTestCase {
         constructor.trackInputFocus(searchTerm: searchTerm)
         self.wait(for: builder.expectation)
     }
-    
+
     func testTrackInputFocus_WithEmptyTestCellValue() {
         let config = ConstructorIOConfig(apiKey: "key_OucJxxrfiTVUQx0C", testCells: [
             CIOABTestCell(key: "hi", value: "")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseFacetsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseFacetsTests.swift
@@ -107,7 +107,6 @@ class ConstructorIOBrowseFacetsTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
-
     func testBrowseFacets_UsingQueryBuilder_WithValidRequest_ReturnsNonNilResponse() {
         let expectation = self.expectation(description: "Calling Browse Facets with valid parameters should return a non-nil response.")
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseGroupsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseGroupsTests.swift
@@ -27,7 +27,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
         let query = CIOBrowseGroupsQuery()
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups should send a valid request.", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&i=\(kRegexClientID)&key=key_OucJxxrfiTVUQx0C&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { _ in })
@@ -39,7 +39,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
 
         let query = CIOBrowseGroupsQuery()
         let dataToReturn = TestResource.load(name: TestResource.Response.searchJSONFilename)
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), http(200, data: dataToReturn))
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { response in
@@ -53,7 +53,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
         let expectation = self.expectation(description: "Calling BrowseGroups returns non-nil error if API errors out.")
 
         let query = CIOBrowseGroupsQuery()
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), http(404))
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { response in
@@ -68,7 +68,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
         let query = CIOBrowseGroupsQuery(section: customSection)
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups should send a valid request.", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=\(customSection)"), builder.create())
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { _ in })
@@ -79,7 +79,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
         let query = CIOBrowseGroupsQuery(groupId: "151")
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups with a group filter should have a group_id URL query item.", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&filters%5Bgroup_id%5D=151&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { _ in })
@@ -90,7 +90,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
         let query = CIOBrowseGroupsQuery(groupsMaxDepth: 5)
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups with groups sort option should return a response", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&fmt_options%5Bgroups_max_depth%5D=5&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browseGroups(forQuery: query) { _ in }
@@ -114,13 +114,13 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
             .build()
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups with valid parameters should return a non-nil response.", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&fmt_options%5Bgroups_max_depth%5D=5&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { _ in })
         self.wait(for: builder.expectation)
     }
-    
+
     func testBrowseGroups_UsingBrowseGroupsQueryBuilder_AttachesCustomSection() {
         let customSection = "customSection"
         let query = CIOBrowseGroupsQueryBuilder()
@@ -128,20 +128,20 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
             .build()
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups with custom section should return a non-nil response.", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=\(customSection)"), builder.create())
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { _ in })
         self.wait(for: builder.expectation)
     }
-    
+
     func testBrowseGroups_UsingBrowseGroupsQueryBuilder_AttachesSpecificGroupId() {
         let query = CIOBrowseGroupsQueryBuilder()
             .setGroupId("151")
             .build()
 
         let builder = CIOBuilder(expectation: "Calling BrowseGroups with a group filter should have a group_id URL query item.", builder: http(200))
-        
+
         stub(regex("https://ac.cnstrc.com/browse/groups?c=\(kRegexVersion)&filters%5Bgroup_id%5D=151&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&section=Products"), builder.create())
 
         self.constructor.browseGroups(forQuery: query, completionHandler: { _ in })

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
@@ -141,11 +141,11 @@ class ConstructorIOBrowseTests: XCTestCase {
 
         self.wait(for: builder.expectation)
     }
-    
+
     func testBrowse_AttachesPreFilterExpression() {
         let preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}"
         let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet", preFilterExpression: preFilterExpression)
-        
+
         let builder = CIOBuilder(expectation: "Calling Browse with pre filter expression should have a URL query pre_filter_expression", builder: http(200))
         stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&pre_filter_expression=%7B%22or%22:%5B%7B%22and%22:%5B%7B%22name%22:%22group_id%22,%22value%22:%22electronics-group-id%22%7D,%7B%22name%22:%22Price%22,%22range%22:%5B%22-inf%22,200.0%5D%7D%5D%7D,%7B%22and%22:%5B%7B%22name%22:%22Type%22,%22value%22:%22Laptop%22%7D,%7B%22not%22:%7B%22name%22:%22Price%22,%22range%22:%5B800.0,%22inf%22%5D%7D%7D%5D%7D%5D%7D&s=\(kRegexSession)&section=Products"), builder.create())
 
@@ -153,7 +153,6 @@ class ConstructorIOBrowseTests: XCTestCase {
 
         self.wait(for: builder.expectation)
     }
-
 
     func testBrowse_WithPlusSignInQueryParams_ShouldBeEncoded() {
         let facetFilters = [

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -432,7 +432,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
             let responseData = response.data!
             let results = responseData.results
             XCTAssertFalse(results.isEmpty)
-            
+
             let request = responseData.request
             XCTAssertNotNil(request)
 
@@ -494,11 +494,11 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testSearch_WithPreFilterExpression() {
         let expectation = XCTestExpectation(description: "Request 204")
         let preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}"
-        
+
         let query = CIOSearchQuery(query: "item", preFilterExpression: preFilterExpression)
         self.constructor.search(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
@@ -511,7 +511,6 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-
 
     func testSearch_WithHiddenFields() {
         let expectation = XCTestExpectation(description: "Request 204")
@@ -715,7 +714,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testSearch_ShouldReturnFacetsData() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
         let expectation = XCTestExpectation(description: "Request 204")
@@ -746,7 +745,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
             let responseData = response.data!
             let results = responseData.results
             XCTAssertFalse(results.isEmpty)
-            
+
             let request = responseData.request
             XCTAssertNotNil(request)
 
@@ -820,11 +819,11 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowse_WithPreFilterExpression() {
         let expectation = XCTestExpectation(description: "Request 204")
         let preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}"
-        
+
         let query = CIOBrowseQuery(filterName: groupFilterName, filterValue: groupFilterValue, preFilterExpression: preFilterExpression)
         self.constructor.browse(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
@@ -1086,7 +1085,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowse_ShouldReturnFacetsData() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
         let expectation = XCTestExpectation(description: "Request 204")
@@ -1255,16 +1254,16 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowseGroups() {
         let expectation = XCTestExpectation(description: "Request 200")
         let query = CIOBrowseGroupsQuery()
-        
+
         self.constructor.config.segments = nil
         self.constructor.browseGroups(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let groupIds = response.data?.groups.compactMap { $0.groupID }
-            
+
             XCTAssertNil(cioError)
             XCTAssertNotNil(groupIds)
             XCTAssertTrue(groupIds?.contains(self.groupId) == true)
@@ -1272,46 +1271,46 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowseGroups_WithSpecificGroupId() {
         let expectation = XCTestExpectation(description: "Request 200")
         let query = CIOBrowseGroupsQuery(groupId: "Styles")
-        
+
         self.constructor.config.segments = nil
         self.constructor.browseGroups(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
-            
+
             let parentGroup = response.data?.groups[0]
             let grandparentsGroupIds = parentGroup?.parents.compactMap { $0.groupID }
             let childGroupIds = parentGroup?.children.compactMap { $0.groupID }
-            
+
             XCTAssertTrue(grandparentsGroupIds?.contains(self.groupId) ?? false)
             XCTAssertTrue(childGroupIds?.contains("StyleA") ?? false)
             XCTAssertTrue(childGroupIds?.contains("StyleB") ?? false)
-            
+
             expectation.fulfill()
         })
         self.wait(for: expectation)
     }
-    
+
     func testBrowseGroups_WithMaxDepth() {
         let expectation = XCTestExpectation(description: "Request 200")
         let query = CIOBrowseGroupsQuery(groupsMaxDepth: 2)
-        
+
         self.constructor.config.segments = nil
         self.constructor.browseGroups(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
-            
+
             let parentGroup = response.data?.groups[0]
             XCTAssertNotNil(parentGroup?.children)
             XCTAssertFalse(parentGroup?.children.isEmpty ?? true)
-            
+
             let childGroup = parentGroup?.children[0]
             XCTAssertNotNil(childGroup?.children)
             XCTAssertFalse(childGroup?.children.isEmpty ?? true)
-            
+
             let grandchildGroup = childGroup?.children[0]
             XCTAssertNotNil(grandchildGroup?.children)
             XCTAssertTrue(grandchildGroup?.children.isEmpty ?? false)
@@ -1319,7 +1318,6 @@ class ConstructorIOIntegrationTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-
 
     func testBrowseFacets() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -1414,3 +1414,4 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 }
+// swiftlint:enable type_body_length file_length

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
@@ -6,8 +6,8 @@
 //  http://constructor.io/
 //
 
-import XCTest
 import ConstructorAutocomplete
+import XCTest
 
 // swiftlint:disable type_body_length
 class ConstructorIOQuizIntegrationTests: XCTestCase {

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizTests.swift
@@ -6,15 +6,15 @@
 //  http://constructor.io/
 //
 
-import XCTest
 import ConstructorAutocomplete
+import XCTest
 
 class ConstructorIOQuizTests: XCTestCase {
 
     var constructor: ConstructorIO!
     var quizSessionId = "session-id"
     var quizVersionId = "dd10eea4-f765-4bb1-b8e5-46b09a190cfe"
-    
+
     override func setUp() {
         super.setUp()
         self.constructor = ConstructorIO(config: ConstructorIOConfig(apiKey: "ZqXaOfXuBWD4s3XzCI1q", baseURL: "https://quizzes.cnstrc.com"))

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
@@ -191,11 +191,11 @@ class ConstructorIOSearchTests: XCTestCase {
 
         self.wait(for: builder.expectation)
     }
-    
+
     func testSearch_AttachesPreFilterExpression() {
         let preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}"
         let query = CIOSearchQuery(query: "potato", preFilterExpression: preFilterExpression)
-        
+
         let builder = CIOBuilder(expectation: "Calling Search with pre filter expression should have a URL query pre_filter_expression", builder: http(200))
         stub(regex("https://ac.cnstrc.com/search/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&pre_filter_expression=%7B%22or%22:%5B%7B%22and%22:%5B%7B%22name%22:%22group_id%22,%22value%22:%22electronics-group-id%22%7D,%7B%22name%22:%22Price%22,%22range%22:%5B%22-inf%22,200.0%5D%7D%5D%7D,%7B%22and%22:%5B%7B%22name%22:%22Type%22,%22value%22:%22Laptop%22%7D,%7B%22not%22:%7B%22name%22:%22Price%22,%22range%22:%5B800.0,%22inf%22%5D%7D%7D%5D%7D%5D%7D&s=\(kRegexSession)&section=Products"), builder.create())
 
@@ -203,7 +203,6 @@ class ConstructorIOSearchTests: XCTestCase {
 
         self.wait(for: builder.expectation)
     }
-
 
     func testSearch_WithPlusSignInQueryParams_ShouldBeEncoded() {
         let facetFilters = [

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackItemDetailLoadTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackItemDetailLoadTests.swift
@@ -6,9 +6,9 @@
 //  http://constructor.io/
 //
 
-import XCTest
-import OHHTTPStubs
 import ConstructorAutocomplete
+import OHHTTPStubs
+import XCTest
 
 class ConstructorIOTrackItemDetailLoadTests: XCTestCase {
 


### PR DESCRIPTION
### Updates:
* There was a lint error that was causing issues with one of our customers. Adding `swiftlint:disable type_body_length file_length` should resolve the issue.
* Ran `swiftlint --fix` which fixed a lot of trailing white space and comma issues
* All tests pass, aside from the flaky `browseGroups` test

### Notes:
* Follow the steps [here](https://constructor.slab.com/posts/setting-up-and-running-the-i-os-swift-repository-ry475ixw#hcgvk-installing-swift-lint) to make sure you have SwiftLint installed correctly
* There are still quite a few other linting warnings that we'll want to resolve another time. Will create a story for that.