### PR TITLE
[CSL-2781] Use ID instead of Id for attribute/variable names for Quizzes-related methods

### DIFF
--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -285,9 +285,9 @@ struct Constants {
         struct Results {
             static let format = "%@/v1/quizzes/%@/results"
         }
-        static let quizId = "quiz_id"
+        static let quizID = "quiz_id"
         static let answers = "a"
-        static let quizVersionId = "quiz_version_id"
-        static let quizSessionId = "quiz_session_id"
+        static let quizVersionID = "quiz_version_id"
+        static let quizSessionID = "quiz_session_id"
     }
 }

--- a/AutocompleteClient/FW/API/Parser/Quizzes/QuizQuestionResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Quizzes/QuizQuestionResponseParser.swift
@@ -13,17 +13,17 @@ class QuizQuestionResponseParser: AbstractQuizQuestionResponseParser {
 
         do {
             let json = try JSONSerialization.jsonObject(with: quizQuestionResponseData) as? JSONObject
-            let quizVersionId = json?["quiz_version_id"] as? String ?? ""
-            let quizId = json?["quiz_id"] as? String ?? ""
-            let quizSessionId = json?["quiz_session_id"] as? String ?? ""
+            let quizVersionID = json?["quiz_version_id"] as? String ?? ""
+            let quizID = json?["quiz_id"] as? String ?? ""
+            let quizSessionID = json?["quiz_session_id"] as? String ?? ""
             let isLastQuestion = json?["is_last_question"] as? Bool ?? false
             let nextQuestion = CIOQuizQuestion(json: json?["next_question"] as? JSONObject ?? [:])
 
             return CIOQuizQuestionResponse(
                 nextQuestion: nextQuestion!,
-                quizVersionId: quizVersionId,
-                quizSessionId: quizSessionId,
-                quizId: quizId,
+                quizVersionID: quizVersionID,
+                quizSessionID: quizSessionID,
+                quizID: quizID,
                 isLastQuestion: isLastQuestion
             )
         } catch {

--- a/AutocompleteClient/FW/API/Parser/Quizzes/QuizResultsResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Quizzes/QuizResultsResponseParser.swift
@@ -31,9 +31,9 @@ class QuizResultsResponseParser: AbstractQuizResultsResponseParser {
             let resultSources: CIOResultSources? = CIOResultSources(json: response["result_sources"] as? JSONObject)
 
             let resultID = json?["result_id"] as? String ?? ""
-            let quizVersionId = json?["quiz_version_id"] as? String ?? ""
-            let quizId = json?["quiz_id"] as? String ?? ""
-            let quizSessionId = json?["quiz_session_id"] as? String ?? ""
+            let quizVersionID = json?["quiz_version_id"] as? String ?? ""
+            let quizID = json?["quiz_id"] as? String ?? ""
+            let quizSessionID = json?["quiz_session_id"] as? String ?? ""
 
             guard let request: JSONObject = json?["request"] as? JSONObject else {
                 throw CIOError(errorType: .invalidResponse)
@@ -47,9 +47,9 @@ class QuizResultsResponseParser: AbstractQuizResultsResponseParser {
                 totalNumResults: totalNumResults,
                 resultSources: resultSources,
                 resultID: resultID,
-                quizVersionId: quizVersionId,
-                quizSessionId: quizSessionId,
-                quizId: quizId,
+                quizVersionID: quizVersionID,
+                quizSessionID: quizSessionID,
+                quizID: quizID,
                 request: request
             )
         } catch {

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -243,13 +243,13 @@ extension RequestBuilder {
         }
     }
 
-    func set(quizVersionId: String?) {
-        guard let quizVersionId = quizVersionId else { return }
-        queryItems.add(URLQueryItem(name: Constants.Quiz.quizVersionId, value: quizVersionId))
+    func set(quizVersionID: String?) {
+        guard let quizVersionID = quizVersionID else { return }
+        queryItems.add(URLQueryItem(name: Constants.Quiz.quizVersionID, value: quizVersionID))
     }
 
-    func set(quizSessionId: String?) {
-        guard let quizSessionId = quizSessionId else { return }
-        queryItems.add(URLQueryItem(name: Constants.Quiz.quizSessionId, value: quizSessionId))
+    func set(quizSessionID: String?) {
+        guard let quizSessionID = quizSessionID else { return }
+        queryItems.add(URLQueryItem(name: Constants.Quiz.quizSessionID, value: quizSessionID))
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOQuizQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOQuizQuery.swift
@@ -14,7 +14,7 @@ public struct CIOQuizQuery: CIORequestData {
     /**
      The id of the quiz
      */
-    public let quizId: String
+    public let quizID: String
 
     /**
      A list of answers. Please refer to "https://docs.constructor.io/rest_api/quiz/using_quizzes/" for additional details
@@ -26,47 +26,47 @@ public struct CIOQuizQuery: CIORequestData {
      The quiz version id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
      */
-    public var quizVersionId: String?
+    public var quizVersionID: String?
 
     /**
      Unique quiz_session_id for the quiz.
      The quiz session id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-sessions
      */
-    public var quizSessionId: String?
+    public var quizSessionID: String?
 
     func url(with baseURL: String) -> String {
         return "" // Do nothing - Returns empty string to satsify protocol requirement
     }
 
     func urlWithFormat(baseURL: String, format: String) -> String {
-        return String(format: format, baseURL, quizId)
+        return String(format: format, baseURL, quizID)
     }
 
     /**
      Create a Quiz request query object
 
      - Parameters:
-        - quizId: The id of the quiz
+        - quizID: The id of the quiz
         - answers: A list of answers
-        - quizVersionId: The version of the quiz you would like to request
-        - quizSessionId: The identifier for the current session of the quiz
+        - quizVersionID: The version of the quiz you would like to request
+        - quizSessionID: The identifier for the current session of the quiz
 
      ### Usage Example: ###
      ```
-     let quizQuery = CIOQuizQuery(quizId: "123", answers: [["1"], ["1","2"]], quizVersionId: "some-version-id")
+     let quizQuery = CIOQuizQuery(quizID: "123", answers: [["1"], ["1","2"]], quizVersionID: "some-version-id")
      ```
      */
-    public init(quizId: String, answers: [[String]]? = nil, quizVersionId: String? = nil, quizSessionId: String? = nil) {
-        self.quizId = quizId
+    public init(quizID: String, answers: [[String]]? = nil, quizVersionID: String? = nil, quizSessionID: String? = nil) {
+        self.quizID = quizID
         self.answers = answers
-        self.quizVersionId = quizVersionId
-        self.quizSessionId = quizSessionId
+        self.quizVersionID = quizVersionID
+        self.quizSessionID = quizSessionID
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
         requestBuilder.set(answers: self.answers)
-        requestBuilder.set(quizVersionId: self.quizVersionId)
-        requestBuilder.set(quizSessionId: self.quizSessionId)
+        requestBuilder.set(quizVersionID: self.quizVersionID)
+        requestBuilder.set(quizSessionID: self.quizSessionID)
     }
 }

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizQuestionResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizQuestionResponse.swift
@@ -22,19 +22,19 @@ public struct CIOQuizQuestionResponse {
      The quiz version id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
      */
-    public let quizVersionId: String
+    public let quizVersionID: String
 
     /**
      Unique quiz_session_id for the quiz.
      The quiz session id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-sessions
      */
-    public let quizSessionId: String
+    public let quizSessionID: String
 
     /**
      Id of the quiz
      */
-    public let quizId: String
+    public let quizID: String
 
     /**
      Flag to determine if it's the last question in the quiz

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizResultsResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOQuizResultsResponse.swift
@@ -52,19 +52,19 @@ public struct CIOQuizResultsResponse {
      The quiz version id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-versioning
      */
-    public let quizVersionId: String
+    public let quizVersionID: String
 
     /**
      Unique quiz_session_id for the quiz.
      The quiz session id will be returned with the first request and it should be passed with subsequent requests.
      More information can be found: https://docs.constructor.io/rest_api/quiz/using_quizzes/#quiz-sessions
      */
-    public let quizSessionId: String
+    public let quizSessionID: String
 
     /**
      Id of the quiz
      */
-    public let quizId: String
+    public let quizID: String
     
     /**
      Request object used to retrieve the Quizzes Response

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -282,7 +282,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
      ### Usage Example: ###
      ```
-     let quizQuestionQuery = CIOQuizQuery(quizId: "123", answers: [["1"], ["1", "2"]], quizVersionId: "some-version-id", quizSessionId: "some-session-id")
+     let quizQuestionQuery = CIOQuizQuery(quizID: "123", answers: [["1"], ["1", "2"]], quizVersionID: "some-version-id", quizSessionID: "some-session-id")
 
      constructorIO.getQuizNextQuestion(forQuery: quizQuestionQuery) { response in
         let data = response.data!
@@ -304,7 +304,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
      ### Usage Example: ###
      ```
-     let quizResultsQuery = CIOQuizQuery(quizId: "123", answers: [["1"], ["1", "2"]], quizVersionId: "some-version-id", quizSessionId: "some-session-id")
+     let quizResultsQuery = CIOQuizQuery(quizID: "123", answers: [["1"], ["1", "2"]], quizVersionID: "some-version-id", quizSessionID: "some-session-id")
      
      constructorIO.getQuizResults(forQuery: quizResultsQuery) { response in
         let data = response.data!

--- a/AutocompleteClientTests/FW/Logic/Request/QuizzesQueryRequestBuilderTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/QuizzesQueryRequestBuilderTests.swift
@@ -10,10 +10,10 @@
 import XCTest
 
 class QuizzesQueryRequestBuilderTests: XCTestCase {
-    fileprivate let quizId: String = "1"
+    fileprivate let quizID: String = "1"
     fileprivate let answers: [[String]] = [["1"], ["2", "3"], ["seen"], ["true"]]
-    fileprivate let quizVersionId: String = "version-id"
-    fileprivate let quizSessionId: String = "session-id"
+    fileprivate let quizVersionID: String = "version-id"
+    fileprivate let quizSessionID: String = "session-id"
     fileprivate var endodedQuery: String = ""
     fileprivate let testACKey: String = "abcdefgh123"
     fileprivate var builder: RequestBuilder!
@@ -24,12 +24,12 @@ class QuizzesQueryRequestBuilderTests: XCTestCase {
     }
 
     func testQuizQueryBuilder_NextQuestion() {
-        let query = CIOQuizQuery(quizId: self.quizId, answers: self.answers, quizVersionId: self.quizVersionId, quizSessionId: self.quizSessionId)
+        let query = CIOQuizQuery(quizID: self.quizID, answers: self.answers, quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         builder.build(trackData: query)
         let request = builder.getQuizRequest(finalize: false)
         let url = request.url!.absoluteString
         print(url)
-        XCTAssertTrue(url.hasPrefix("https://quizzes.cnstrc.com/v1/quizzes/\(quizId)/next"))
+        XCTAssertTrue(url.hasPrefix("https://quizzes.cnstrc.com/v1/quizzes/\(quizID)/next"))
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain api key.")
         XCTAssertTrue(url.contains("quiz_version_id=version-id"), "URL should contain the quiz version id")
@@ -38,12 +38,12 @@ class QuizzesQueryRequestBuilderTests: XCTestCase {
     }
 
     func testQuizQueryBuilder_QuizResults() {
-        let query = CIOQuizQuery(quizId: self.quizId, answers: self.answers, quizVersionId: self.quizVersionId, quizSessionId: self.quizSessionId)
+        let query = CIOQuizQuery(quizID: self.quizID, answers: self.answers, quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         builder.build(trackData: query)
         let request = builder.getQuizRequest(finalize: true)
         let url = request.url!.absoluteString
 
-        XCTAssertTrue(url.hasPrefix("https://quizzes.cnstrc.com/v1/quizzes/\(quizId)/results"))
+        XCTAssertTrue(url.hasPrefix("https://quizzes.cnstrc.com/v1/quizzes/\(quizID)/results"))
         XCTAssertTrue(url.contains("c=cioios-"), "URL should contain the version string.")
         XCTAssertTrue(url.contains("key=\(testACKey)"), "URL should contain api key.")
         XCTAssertTrue(url.contains("quiz_version_id=version-id"), "URL should contain the quiz version id")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
@@ -14,17 +14,17 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     fileprivate let unitTestKey = "key_vM4GkLckwiuxwyRA"
     fileprivate let session = 90
-    fileprivate let quizVersionId = "e03210db-0cc6-459c-8f17-bf014c4f554d"
-    fileprivate let quizSessionId = "session-id"
+    fileprivate let quizVersionID = "e03210db-0cc6-459c-8f17-bf014c4f554d"
+    fileprivate let quizSessionID = "session-id"
     fileprivate let sectionName = "Products"
 
     // For tracking
-    fileprivate let quizId = "test-quiz"
-    fileprivate let customerId = "960109549"
-    fileprivate let variationId = "no variations"
+    fileprivate let quizID = "test-quiz"
+    fileprivate let customerID = "960109549"
+    fileprivate let variationID = "no variations"
     fileprivate let itemName = "Lucerne Cottage Cheese Small Curd 2% Milkfat Lowfat - 24 Oz"
     fileprivate let url = "www.example.com"
-    fileprivate let resultId = "abc"
+    fileprivate let resultID = "abc"
     fileprivate let resultPage = 1
     fileprivate let resultCount = 12
     fileprivate let numResultsPerPage = 13
@@ -49,13 +49,13 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz")
+        let query = CIOQuizQuery(quizID: "test-quiz")
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertNotEqual(responseData.quizVersionId, "")
+            XCTAssertNotEqual(responseData.quizVersionID, "")
             XCTAssertEqual(responseData.isLastQuestion, false)
             XCTAssertEqual(responseData.nextQuestion.id, 1)
             XCTAssertEqual(responseData.nextQuestion.title, "This is a test quiz.")
@@ -81,17 +81,17 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testGetQuizNextQuestion_WithVersionIdAndSessionId() {
+    func testGetQuizNextQuestion_WithVersionIDAndSessionID() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", quizVersionId: self.quizVersionId, quizSessionId: self.quizSessionId)
+        let query = CIOQuizQuery(quizID: "test-quiz", quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertEqual(responseData.quizVersionId, self.quizVersionId)
-            XCTAssertEqual(responseData.quizSessionId, self.quizSessionId)
+            XCTAssertEqual(responseData.quizVersionID, self.quizVersionID)
+            XCTAssertEqual(responseData.quizSessionID, self.quizSessionID)
             XCTAssertEqual(responseData.isLastQuestion, false)
             XCTAssertEqual(responseData.nextQuestion.id, 1)
             XCTAssertEqual(responseData.nextQuestion.title, "This is a test quiz.")
@@ -112,10 +112,10 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testGetQuizNextQuestion_WithInvalidVersionId() {
+    func testGetQuizNextQuestion_WithInvalidVersionID() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", quizVersionId: "1")
+        let query = CIOQuizQuery(quizID: "test-quiz", quizVersionID: "1")
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -130,14 +130,14 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithSingleTypeUsingSingleAnswer() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"]])
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertNotEqual(responseData.quizVersionId, "")
-            XCTAssertNotEqual(responseData.quizSessionId, "")
+            XCTAssertNotEqual(responseData.quizVersionID, "")
+            XCTAssertNotEqual(responseData.quizSessionID, "")
             XCTAssertEqual(responseData.isLastQuestion, false)
             XCTAssertEqual(responseData.nextQuestion.id, 2)
             XCTAssertEqual(responseData.nextQuestion.title, "This is a multiple select question")
@@ -161,7 +161,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithSingleTypeUsingWrongAnswerType() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1", "2"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1", "2"]])
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -176,14 +176,14 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithMultipleTypeUsingMultipleAnswer() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["1", "2"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"]])
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertNotEqual(responseData.quizVersionId, "")
-            XCTAssertNotEqual(responseData.quizSessionId, "")
+            XCTAssertNotEqual(responseData.quizVersionID, "")
+            XCTAssertNotEqual(responseData.quizSessionID, "")
             XCTAssertEqual(responseData.isLastQuestion, false)
             XCTAssertEqual(responseData.nextQuestion.id, 3)
             XCTAssertEqual(responseData.nextQuestion.title, "Test Cover")
@@ -201,7 +201,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithMultipleTypeUsingWrongAnswerType() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["true"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["true"]])
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -216,14 +216,14 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithCoverTypeUsingCoverAnswer() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["1", "2"], ["seen"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["seen"]])
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertNotEqual(responseData.quizVersionId, "")
-            XCTAssertNotEqual(responseData.quizSessionId, "")
+            XCTAssertNotEqual(responseData.quizVersionID, "")
+            XCTAssertNotEqual(responseData.quizSessionID, "")
             XCTAssertEqual(responseData.isLastQuestion, true)
             XCTAssertEqual(responseData.nextQuestion.id, 4)
             XCTAssertEqual(responseData.nextQuestion.title, "Test Open Text")
@@ -242,7 +242,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithCoverTypeUsingWrongAnswerType() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["1", "2"], ["true"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"]])
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -257,15 +257,15 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizResults() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["1", "2"], ["true"], ["seen"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"], ["seen"]])
         constructorClient.getQuizResults(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertNotEqual(responseData.quizVersionId, "")
-            XCTAssertNotEqual(responseData.quizSessionId, "")
-            XCTAssertEqual(responseData.quizId, "test-quiz")
+            XCTAssertNotEqual(responseData.quizVersionID, "")
+            XCTAssertNotEqual(responseData.quizSessionID, "")
+            XCTAssertEqual(responseData.quizID, "test-quiz")
             XCTAssertNotEqual(responseData.resultID, "")
             XCTAssertGreaterThan(responseData.sortOptions.count, 0)
             XCTAssertGreaterThan(responseData.groups.count, 0)
@@ -278,18 +278,18 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testGetQuizResults_WithVersionIdAndSessionId() {
+    func testGetQuizResults_WithVersionIDAndSessionID() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["1", "2"], ["true"], ["seen"]], quizVersionId: self.quizVersionId, quizSessionId: self.quizSessionId)
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"], ["seen"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizResults(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
 
             XCTAssertNil(cioError)
-            XCTAssertEqual(responseData.quizVersionId, self.quizVersionId)
-            XCTAssertEqual(responseData.quizSessionId, self.quizSessionId)
-            XCTAssertEqual(responseData.quizId, "test-quiz")
+            XCTAssertEqual(responseData.quizVersionID, self.quizVersionID)
+            XCTAssertEqual(responseData.quizSessionID, self.quizSessionID)
+            XCTAssertEqual(responseData.quizID, "test-quiz")
             XCTAssertNotEqual(responseData.resultID, "")
             XCTAssertGreaterThan(responseData.sortOptions.count, 0)
             XCTAssertGreaterThan(responseData.groups.count, 0)
@@ -302,10 +302,10 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testGetQuizResults_WithInvalidVersionId() {
+    func testGetQuizResults_WithInvalidVersionID() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizId: "test-quiz", quizVersionId: "1")
+        let query = CIOQuizQuery(quizID: "test-quiz", quizVersionID: "1")
         constructorClient.getQuizResults(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -319,7 +319,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     func testTrackQuizResultClick() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackQuizResultClick(quizID: quizId, quizVersionID: quizVersionId, quizSessionID: quizSessionId, customerID: customerId, completionHandler: { response in
+        self.constructor.trackQuizResultClick(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -329,7 +329,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     func testTrackQuizResultClick_WithOptionalParams() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackQuizResultClick(quizID: quizId, quizVersionID: quizVersionId, quizSessionID: quizSessionId, customerID: customerId, variationID: variationId, itemName: itemName, resultID: resultId, resultPage: resultPage, resultCount: resultCount, numResultsPerPage: numResultsPerPage, resultPositionOnPage: resultPositionOnPage, sectionName: sectionName, completionHandler: { response in
+        self.constructor.trackQuizResultClick(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, variationID: variationID, itemName: itemName, resultID: resultID, resultPage: resultPage, resultCount: resultCount, numResultsPerPage: numResultsPerPage, resultPositionOnPage: resultPositionOnPage, sectionName: sectionName, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -339,7 +339,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     func testTrackQuizResultsLoaded() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackQuizResultsLoaded(quizID: quizId, quizVersionID: quizVersionId, quizSessionID: quizSessionId, completionHandler: { response in
+        self.constructor.trackQuizResultsLoaded(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -349,7 +349,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     func testTrackQuizResultsLoaded_WithOptionalParams() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackQuizResultsLoaded(quizID: quizId, quizVersionID: quizVersionId, quizSessionID: quizSessionId,  resultID: resultId, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, completionHandler: { response in
+        self.constructor.trackQuizResultsLoaded(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID,  resultID: resultID, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -359,7 +359,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     func testTrackQuizConversion() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackQuizConversion(quizID: quizId, quizVersionID: quizVersionId, quizSessionID: quizSessionId, customerID: customerId, completionHandler: { response in
+        self.constructor.trackQuizConversion(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -369,7 +369,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     func testTrackQuizConversion_WithOptionalParams() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackQuizConversion(quizID: quizId, quizVersionID: quizVersionId, quizSessionID: quizSessionId, customerID: customerId, variationID: variationId, itemName: itemName, revenue: revenue, conversionType: conversionType, isCustomType: isCustomType, displayName: displayName, sectionName: sectionName, completionHandler: { response in
+        self.constructor.trackQuizConversion(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, variationID: variationID, itemName: itemName, revenue: revenue, conversionType: conversionType, isCustomType: isCustomType, displayName: displayName, sectionName: sectionName, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizTests.swift
@@ -12,8 +12,8 @@ import XCTest
 class ConstructorIOQuizTests: XCTestCase {
 
     var constructor: ConstructorIO!
-    var quizSessionId = "session-id"
-    var quizVersionId = "dd10eea4-f765-4bb1-b8e5-46b09a190cfe"
+    var quizSessionID = "session-id"
+    var quizVersionID = "dd10eea4-f765-4bb1-b8e5-46b09a190cfe"
 
     override func setUp() {
         super.setUp()
@@ -26,20 +26,20 @@ class ConstructorIOQuizTests: XCTestCase {
     }
 
     func testQuizNextQuestion_CreatesValidRequest() {
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["2"]], quizVersionId: self.quizVersionId, quizSessionId: self.quizSessionId)
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["2"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
 
         let builder = CIOBuilder(expectation: "Calling Quiz Question should send a valid request.", builder: http(200))
-        stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/next?_dt=\(kRegexTimestamp)&a=1&a=2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&quiz_session_id=\(self.quizSessionId)&quiz_version_id=\(self.quizVersionId)&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/next?_dt=\(kRegexTimestamp)&a=1&a=2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&quiz_session_id=\(self.quizSessionID)&quiz_version_id=\(self.quizVersionID)&s=\(kRegexSession)"), builder.create())
 
         self.constructor.getQuizNextQuestion(forQuery: query, completionHandler: { response in })
         self.wait(for: builder.expectation)
     }
 
     func testQuizResults_CreatesValidRequest() {
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["2"]], quizVersionId: self.quizVersionId, quizSessionId: self.quizSessionId)
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["2"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
 
         let builder = CIOBuilder(expectation: "Calling Quiz Results should send a valid request.", builder: http(200))
-        stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=1&a=2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&quiz_session_id=\(self.quizSessionId)&quiz_version_id=\(self.quizVersionId)&s=\(kRegexSession)"), builder.create())
+        stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=1&a=2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&quiz_session_id=\(self.quizSessionID)&quiz_version_id=\(self.quizVersionID)&s=\(kRegexSession)"), builder.create())
 
         self.constructor.getQuizResults(forQuery: query, completionHandler: { response in })
         self.wait(for: builder.expectation)
@@ -48,7 +48,7 @@ class ConstructorIOQuizTests: XCTestCase {
     func testQuizNextQuestion_WithValidRequest_ReturnsNonNilResponse() {
         let expectation = self.expectation(description: "Calling Quiz Question with valid parameters should return a non-nil response.")
 
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"]])
 
         let dataToReturn = TestResource.load(name: TestResource.Response.quizQuestionJSONFilename)
         stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/next?_dt=\(kRegexTimestamp)&a=1&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)"), http(200, data: dataToReturn))
@@ -67,7 +67,7 @@ class ConstructorIOQuizTests: XCTestCase {
     func testQuizResults_WithValidRequest_ReturnsNonNilResponse() {
         let expectation = self.expectation(description: "Calling Quiz Results with valid parameters should return a non-nil response.")
 
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["2, 3"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["2, 3"]])
 
         let dataToReturn = TestResource.load(name: TestResource.Response.quizResultsJSONFilename)
         stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=1&a=2,3&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)"), http(200, data: dataToReturn))
@@ -82,7 +82,7 @@ class ConstructorIOQuizTests: XCTestCase {
     func testQuizResults_WithValidRequest_ReturnsNonNilResponseWithRequestObject() {
         let expectation = self.expectation(description: "Calling Quiz Results with valid parameters should return a non-nil response with the request object.")
 
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["2, 3"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["2, 3"]])
 
         let dataToReturn = TestResource.load(name: TestResource.Response.quizResultsJSONFilename)
         stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=1&a=2,3&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)"), http(200, data: dataToReturn))
@@ -99,7 +99,7 @@ class ConstructorIOQuizTests: XCTestCase {
     func testQuizNextQuestion_ReturnsErrorObject_IfAPIReturnsInvalidResponse() {
         let expectation = self.expectation(description: "Calling Quiz Question returns non-nil error if API errors out.")
 
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["2"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["2"]])
         stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/next?_dt=\(kRegexTimestamp)&a=1&a=2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)"), http(404))
 
         self.constructor.getQuizNextQuestion(forQuery: query, completionHandler: { response in
@@ -112,7 +112,7 @@ class ConstructorIOQuizTests: XCTestCase {
     func testQuizResults_ReturnsErrorObject_IfAPIReturnsInvalidResponse() {
         let expectation = self.expectation(description: "Calling Quiz Results returns non-nil error if API errors out.")
 
-        let query = CIOQuizQuery(quizId: "test-quiz", answers: [["1"], ["2"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["2"]])
         stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=1&a=2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)"), http(404))
 
         self.constructor.getQuizResults(forQuery: query, completionHandler: { response in

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ constructorIO.recommendations(forQuery: query) { (response) in
 ## 10. Request Quiz Next Question
 
 ```swift
-let query = CIOQuizQuery(quizId: "quiz-1", answers: [["1"], ["2"]])
+let query = CIOQuizQuery(quizID: "quiz-1", answers: [["1"], ["2"]])
 
 constructorIO.getQuizNextQuestion(forQuery: query) { (response) in
   let data = response.data!
@@ -201,7 +201,7 @@ constructorIO.getQuizNextQuestion(forQuery: query) { (response) in
 ## 11. Request Quiz Results
 
 ```swift
-let query = CIOQuizQuery(quizId: "quiz-1", answers: [["1"], ["2"]])
+let query = CIOQuizQuery(quizID: "quiz-1", answers: [["1"], ["2"]])
 
 constructorIO.getQuizResults(forQuery: query) { (response) in
   let data = response.data!


### PR DESCRIPTION
The rest of the repository largely follows the convention `<variable>ID`. This PR makes Quizzes-related methods consistent w/ the rest of the repo.

Note: As I was doing this story, I also noted other instances where we do `<variable>Id` instead of `<variable>ID`
- browseGroups - `groupId`
- CIOResultData - `variationId`

Since these might already be in use, it might require additional lift and discussion to make backwards compatible.