### PR TITLE
Fix issue with resultID in browse result loaded event

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/CIOTrackBrowseResultsLoadedData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackBrowseResultsLoadedData.swift
@@ -52,7 +52,7 @@ struct CIOTrackBrowseResultsLoadedData: CIORequestData {
         }
 
         if self.resultID != nil {
-            dict["resultID"] = self.resultID
+            dict["result_id"] = self.resultID
         }
 
         dict["beacon"] = true

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackBrowseResultsLoadedData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackBrowseResultsLoadedData.swift
@@ -45,7 +45,7 @@ struct CIOTrackBrowseResultsLoadedData: CIORequestData {
             "result_count": Int(self.resultCount),
             "url": self.url
         ] as [String: Any]
-        
+
         if let loadedCustomerIDs = self.customerIDs {
             let items = loadedCustomerIDs.map { ["item_id": $0] }
             dict["items"] = items

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -37,6 +37,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
     fileprivate let conversionType = "add_to_cart"
     fileprivate let itemIds = ["10003", "10004", "10005", "10006", "10007"]
     fileprivate let groupId = "All"
+    fileprivate let resultID = "result-id"
 
     var constructor: ConstructorIO!
 
@@ -62,7 +63,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testTrackAutocompleteSelect() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackAutocompleteSelect(searchTerm: searchTerm, originalQuery: originalQuery, sectionName: sectionName, group: group, resultID: nil, completionHandler: { response in
+        self.constructor.trackAutocompleteSelect(searchTerm: searchTerm, originalQuery: originalQuery, sectionName: sectionName, group: group, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -92,7 +93,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testSearchResultClick() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackSearchResultClick(itemName: itemName, customerID: customerID, searchTerm: searchTerm, sectionName: sectionName, resultID: nil, completionHandler: { response in
+        self.constructor.trackSearchResultClick(itemName: itemName, customerID: customerID, searchTerm: searchTerm, sectionName: sectionName, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -112,7 +113,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testBrowseResultsLoaded() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackBrowseResultsLoaded(filterName: groupFilterName, filterValue: groupFilterValue, resultCount: resultCount, resultID: nil, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: groupFilterName, filterValue: groupFilterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -122,7 +123,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
     
     func testBrowseResultsLoaded_withItems() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackBrowseResultsLoaded(filterName: groupFilterName, filterValue: groupFilterValue, resultCount: resultCount, customerIDs: customerIDs, resultID: nil, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: groupFilterName, filterValue: groupFilterValue, resultCount: resultCount, customerIDs: customerIDs, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -132,7 +133,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testBrowseResultClick() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackBrowseResultClick(customerID: customerID, filterName: groupFilterName, filterValue: groupFilterValue, resultPositionOnPage: resultPositionOnPage, sectionName: sectionName, resultID: nil, completionHandler: { response in
+        self.constructor.trackBrowseResultClick(customerID: customerID, filterName: groupFilterName, filterValue: groupFilterValue, resultPositionOnPage: resultPositionOnPage, sectionName: sectionName, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -143,7 +144,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
     func testBrowseResultClick_WithVariationID() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: testACKey))
         let expectation = XCTestExpectation(description: "Request 204")
-        constructorClient.trackBrowseResultClick(customerID: "10001", variationID: "20001", filterName: "Brand", filterValue: "XYZ", resultPositionOnPage: 1, sectionName: "Products", completionHandler: { response in
+        constructorClient.trackBrowseResultClick(customerID: "10001", variationID: "20001", filterName: "Brand", filterValue: "XYZ", resultPositionOnPage: 1, sectionName: "Products", resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -152,7 +153,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testRecommendationsResultsView() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackRecommendationResultsView(podID: podID, numResultsViewed: numResultsViewed, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: nil, completionHandler: { response in
+        self.constructor.trackRecommendationResultsView(podID: podID, numResultsViewed: numResultsViewed, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()
@@ -162,7 +163,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
 
     func testRecommendationsResultClick() {
         let expectation = XCTestExpectation(description: "Tracking 204")
-        self.constructor.trackRecommendationResultClick(podID: podID, strategyID: strategyID, customerID: customerID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: sectionName, resultID: nil, completionHandler: { response in
+        self.constructor.trackRecommendationResultClick(podID: podID, strategyID: strategyID, customerID: customerID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: sectionName, resultID: resultID, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNil(cioError)
             expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultsLoadedTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultsLoadedTests.swift
@@ -33,14 +33,14 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     func testTrackBrowseResultsLoaded() {
         let builder = CIOBuilder(expectation: "Calling trackBrowseResultsLoaded should send a valid request.", builder: http(200))
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), builder.create())
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID)
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, customerIDs: customerIDs, resultID: resultID)
         self.wait(for: builder.expectation)
     }
 
     func testTrackBrowseResultsLoaded_With400() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with 400 should return badRequest CIOError.")
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(400))
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, customerIDs: customerIDs, resultID: resultID, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError.errorType, .badRequest, "If tracking call returns status code 400, the error should be delegated to the completion handler")
                 expectation.fulfill()
@@ -52,7 +52,7 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     func testTrackBrowseResultsLoaded_With500() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with 500 should return internalServerError CIOError.")
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(500))
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, customerIDs: customerIDs, resultID: resultID, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError.errorType, .internalServerError, "If tracking call returns status code 500, the error should be delegated to the completion handler")
                 expectation.fulfill()
@@ -64,7 +64,7 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     func testTrackBrowseResultsLoaded_WithNoConnectivity() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with no connectvity should return noConnectivity CIOError.")
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), noConnectivity())
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, customerIDs: customerIDs, resultID: resultID, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError.errorType, .noConnection, "If tracking call returns no connectivity, the error should be delegated to the completion handler")
                 expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultsLoadedTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultsLoadedTests.swift
@@ -40,7 +40,7 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     func testTrackBrowseResultsLoaded_With400() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with 400 should return badRequest CIOError.")
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(400))
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError.errorType, .badRequest, "If tracking call returns status code 400, the error should be delegated to the completion handler")
                 expectation.fulfill()
@@ -52,7 +52,7 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     func testTrackBrowseResultsLoaded_With500() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with 500 should return internalServerError CIOError.")
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(500))
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError.errorType, .internalServerError, "If tracking call returns status code 500, the error should be delegated to the completion handler")
                 expectation.fulfill()
@@ -64,7 +64,7 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     func testTrackBrowseResultsLoaded_WithNoConnectivity() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with no connectvity should return noConnectivity CIOError.")
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), noConnectivity())
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, completionHandler: { response in
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, completionHandler: { response in
             if let cioError = response.error as? CIOError {
                 XCTAssertEqual(cioError.errorType, .noConnection, "If tracking call returns no connectivity, the error should be delegated to the completion handler")
                 expectation.fulfill()

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultsLoadedTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackBrowseResultsLoadedTests.swift
@@ -12,6 +12,12 @@ import XCTest
 
 class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
 
+    fileprivate let filterName = "potato"
+    fileprivate let filterValue = "russet"
+    fileprivate let resultCount = 12
+    fileprivate let resultID = "result-id"
+    fileprivate let customerIDs = ["10001", "10002"]
+
     var constructor: ConstructorIO!
 
     override func setUp() {
@@ -25,20 +31,14 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
     }
 
     func testTrackBrowseResultsLoaded() {
-        let filterName = "potato"
-        let filterValue = "russet"
-        let resultCount = 12
         let builder = CIOBuilder(expectation: "Calling trackBrowseResultsLoaded should send a valid request.", builder: http(200))
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), builder.create())
-        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount)
+        self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID)
         self.wait(for: builder.expectation)
     }
 
     func testTrackBrowseResultsLoaded_With400() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with 400 should return badRequest CIOError.")
-        let filterName = "potato"
-        let filterValue = "russet"
-        let resultCount = 12
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(400))
         self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, completionHandler: { response in
             if let cioError = response.error as? CIOError {
@@ -51,9 +51,6 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
 
     func testTrackBrowseResultsLoaded_With500() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with 500 should return internalServerError CIOError.")
-        let filterName = "potato"
-        let filterValue = "russet"
-        let resultCount = 12
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), http(500))
         self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, completionHandler: { response in
             if let cioError = response.error as? CIOError {
@@ -66,9 +63,6 @@ class ConstructorIOTrackBrowseResultsLoadedTests: XCTestCase {
 
     func testTrackBrowseResultsLoaded_WithNoConnectivity() {
         let expectation = self.expectation(description: "Calling trackBrowseResultsLoaded with no connectvity should return noConnectivity CIOError.")
-        let filterName = "potato"
-        let filterValue = "russet"
-        let resultCount = 12
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/browse_result_load?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)"), noConnectivity())
         self.constructor.trackBrowseResultsLoaded(filterName: filterName, filterValue: filterValue, resultCount: resultCount, completionHandler: { response in
             if let cioError = response.error as? CIOError {


### PR DESCRIPTION
### Updates:
* Made update to the code and updated some of the tests
    * Our server was throwing a 4XX error as our client was passing `resultID` instead of `result_id` in trackBrowseResultsLoaded