### PR TITLE
Update failing tests due to force cast

### DIFF
--- a/AutocompleteClientTests/FW/API/Parser/BrowseResponseParserTest.swift
+++ b/AutocompleteClientTests/FW/API/Parser/BrowseResponseParserTest.swift
@@ -53,18 +53,20 @@ class BrowseResponseParserTests: XCTestCase {
             XCTFail("Parse should never throw an exception when a valid JSON string is passed.")
         }
     }
-    
+
     func testBrowseParser_ParsingJSONString_ParsesLabels() {
         let data = TestResource.load(name: TestResource.Response.browseJSONFilename)
         do {
             let response = try self.parser.parse(browseResponseData: data)
             let labels = response.results[0].labels
-            let newArrivals = labels["__cnstrc_new_arrivals"] as! [String: Any]
 
-            XCTAssertEqual(labels["is_sponsored"] as! Bool, true)
-            XCTAssertEqual(newArrivals["display_name"] as! String, "New Arrival")
-            XCTAssertEqual(newArrivals["test"] as! String, "test")
-
+            if let newArrivals = labels["__cnstrc_new_arrivals"] as? [String: Any] {
+                XCTAssertEqual(labels["is_sponsored"] as? Bool, true)
+                XCTAssertEqual(newArrivals["display_name"] as? String, "New Arrival")
+                XCTAssertEqual(newArrivals["test"] as? String, "test")
+            } else {
+                XCTFail("Expected '__cnstrc_new_arrivals' to be a dictionary")
+            }
         } catch {
             XCTFail("Parse should never throw an exception when a valid JSON string is passed.")
         }

--- a/AutocompleteClientTests/FW/API/Parser/SearchResponseParserTests.swift
+++ b/AutocompleteClientTests/FW/API/Parser/SearchResponseParserTests.swift
@@ -172,17 +172,20 @@ class SearchResponseParserTests: XCTestCase {
             XCTFail("Parse should never throw an exception when a valid JSON string is passed.")
         }
     }
-    
+
     func testSearchParser_ParsingJSONString_ParsesLabels() {
         let data = TestResource.load(name: TestResource.Response.searchJSONRefinedContentFilename)
         do {
             let response = try self.parser.parse(searchResponseData: data)
             let labels = response.results[0].labels
-            let newArrivals = labels["__cnstrc_new_arrivals"] as! [String: Any]
 
-            XCTAssertEqual(labels["is_sponsored"] as! Bool, true)
-            XCTAssertEqual(newArrivals["display_name"] as! String, "New Arrival")
-            XCTAssertEqual(newArrivals["test"] as! String, "test")
+            if let newArrivals = labels["__cnstrc_new_arrivals"] as? [String: Any] {
+                XCTAssertEqual(labels["is_sponsored"] as? Bool, true)
+                XCTAssertEqual(newArrivals["display_name"] as? String, "New Arrival")
+                XCTAssertEqual(newArrivals["test"] as? String, "test")
+            } else {
+                XCTFail("Expected '__cnstrc_new_arrivals' to be a dictionary")
+            }
 
         } catch {
             XCTFail("Parse should never throw an exception when a valid JSON string is passed.")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -523,12 +523,18 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let query = CIOAutocompleteQuery(query: "item")
         self.constructor.autocomplete(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
-            let responseData = response.data!
-            let autocompleteResult = responseData.sections["Products"]?[0]
 
-            XCTAssertNil(cioError)
-            XCTAssertNotNil(autocompleteResult)
-            XCTAssertEqual(autocompleteResult?.result.labels["is_sponsored"] as! Bool, true)
+            if let responseData = response.data,
+               let autocompleteResult = responseData.sections["Products"]?.first,
+               let isSponsored = autocompleteResult.result.labels["is_sponsored"] as? Bool {
+                
+                XCTAssertNil(cioError)
+                XCTAssertNotNil(autocompleteResult)
+                XCTAssertEqual(isSponsored, true)
+            } else {
+                XCTFail("Expected valid response data, autocomplete result, and 'is_sponsored' label")
+            }
+
             expectation.fulfill()
         })
         self.wait(for: expectation)
@@ -760,12 +766,18 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let query = CIOSearchQuery(query: "item")
         constructorClient.search(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
-            let responseData = response.data!
-            let searchResult = responseData.results[0]
-
-            XCTAssertNil(cioError)
-            XCTAssertNotNil(searchResult)
-            XCTAssertEqual(searchResult.labels["is_sponsored"] as! Bool, true)
+            
+            if let responseData = response.data,
+               let searchResult = responseData.results.first,
+               let isSponsored = searchResult.labels["is_sponsored"] as? Bool {
+                
+                XCTAssertNil(cioError)
+                XCTAssertNotNil(searchResult)
+                XCTAssertEqual(isSponsored, true)
+            } else {
+                XCTFail("Expected valid response data, search result, and 'is_sponsored' label")
+            }
+            
             expectation.fulfill()
         })
         self.wait(for: expectation)
@@ -1097,12 +1109,18 @@ class ConstructorIOIntegrationTests: XCTestCase {
         let query = CIOBrowseQuery(filterName: "Brand", filterValue: "XYZ")
         constructorClient.browse(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
-            let responseData = response.data!
-            let browseResult = responseData.results[0]
 
-            XCTAssertNil(cioError)
-            XCTAssertNotNil(browseResult)
-            XCTAssertEqual(browseResult.labels["is_sponsored"] as! Bool, true)
+            if let responseData = response.data,
+               let browseResult = responseData.results.first,
+               let isSponsored = browseResult.labels["is_sponsored"] as? Bool {
+
+                XCTAssertNil(cioError)
+                XCTAssertNotNil(browseResult)
+                XCTAssertEqual(isSponsored, true)
+            } else {
+                XCTFail("Expected valid response data, browse result, and 'is_sponsored' label")
+            }
+
             expectation.fulfill()
         })
         self.wait(for: expectation)


### PR DESCRIPTION
### Updates:
* With the recent xcodebuild update to 16.2, it looks like our tests that are using force casting are causing the builds to fail, this fixes that issue

### Related resource:
* [Setting up and running the Swift repo](https://constructor.slab.com/posts/setting-up-and-running-the-i-os-swift-repository-ry475ixw)