### PR TITLE
CIOFilterFacet - Fix cases when min and max are returned as Double in the response

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseItemsQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseItemsQueryBuilder.swift
@@ -63,6 +63,10 @@ public class CIOBrowseItemsQueryBuilder {
      */
     var groupsSortOption: CIOGroupsSortOption?
     
+    /**
+     The fmt_options to use with the result set
+     Please refer to our docs for more information on available options: https://docs.constructor.com/reference/v1-browse-get-browse-results 
+     */
     var fmtOptions: [FmtOption]?
 
     /**
@@ -147,6 +151,9 @@ public class CIOBrowseItemsQueryBuilder {
         return self
     }
     
+    /**
+     Adds the fmt_options to use with result set 
+     */
     public func setFmtOptions(_ fmtOptions: [FmtOption]?) ->
     CIOBrowseItemsQueryBuilder {
         self.fmtOptions = fmtOptions

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseItemsQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseItemsQueryBuilder.swift
@@ -62,6 +62,8 @@ public class CIOBrowseItemsQueryBuilder {
      The sort method/order for groups
      */
     var groupsSortOption: CIOGroupsSortOption?
+    
+    var fmtOptions: [FmtOption]?
 
     /**
      Create a Browse Items request query builder
@@ -144,7 +146,12 @@ public class CIOBrowseItemsQueryBuilder {
         self.groupsSortOption = groupsSortOption
         return self
     }
-
+    
+    public func setFmtOptions(_ fmtOptions: [FmtOption]?) ->
+    CIOBrowseItemsQueryBuilder {
+        self.fmtOptions = fmtOptions
+        return self
+    }
     /**
      Build the request object set all of the provided data
      
@@ -167,6 +174,6 @@ public class CIOBrowseItemsQueryBuilder {
      ```
      */
     public func build() -> CIOBrowseItemsQuery {
-        return CIOBrowseItemsQuery(ids: ids, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap)
+        return CIOBrowseItemsQuery(ids: ids, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, fmtOptions: fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
@@ -73,6 +73,8 @@ public class CIOBrowseQueryBuilder {
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.com/reference/shared-filter-expressions
      */
     var preFilterExpression: String?
+    
+    var fmtOptions: [FmtOption]?
 
     /**
      Create a Browse request query builder
@@ -165,6 +167,11 @@ public class CIOBrowseQueryBuilder {
         self.preFilterExpression = preFilterExpression
         return self
     }
+    
+    public func setFmtOptions(_ fmtOptions: [FmtOption]?) -> CIOBrowseQueryBuilder {
+        self.fmtOptions = fmtOptions
+        return self
+    }
 
     /**
      Build the request object set all of the provided data
@@ -191,6 +198,6 @@ public class CIOBrowseQueryBuilder {
      ```
      */
     public func build() -> CIOBrowseQuery {
-        return CIOBrowseQuery(filterName: filterName, filterValue: filterValue, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression)
+        return CIOBrowseQuery(filterName: filterName, filterValue: filterValue, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression, fmtOptions: fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
@@ -74,6 +74,10 @@ public class CIOBrowseQueryBuilder {
      */
     var preFilterExpression: String?
     
+    /**
+     The fmt_options to use with the result set
+     Please refer to our docs for more information on available options: https://docs.constructor.com/reference/v1-browse-get-browse-results 
+     */
     var fmtOptions: [FmtOption]?
 
     /**
@@ -168,6 +172,9 @@ public class CIOBrowseQueryBuilder {
         return self
     }
     
+    /**
+     Add the fmt_options to use with result set
+     */
     public func setFmtOptions(_ fmtOptions: [FmtOption]?) -> CIOBrowseQueryBuilder {
         self.fmtOptions = fmtOptions
         return self

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
@@ -69,6 +69,10 @@ public class CIOSearchQueryBuilder {
      */
     var preFilterExpression: String?
 
+    /**
+     The fmt_options to use with the result set
+     Please refer to our docs for more information on available options: https://docs.constructor.com/reference/v1-search-get-search-results
+     */
     var fmtOptions: [FmtOption]?
 
     /**
@@ -158,6 +162,14 @@ public class CIOSearchQueryBuilder {
      */
     public func setVariationsMap(_ variationsMap: CIOQueryVariationsMap) -> CIOSearchQueryBuilder {
         self.variationsMap = variationsMap
+        return self
+    }
+
+    /**
+     Add the fmt_options to use with result set
+     */
+    public func setFmtOptions(_ fmtOptions: [FmtOption]?) -> CIOSearchQueryBuilder {
+        self.fmtOptions = fmtOptions
         return self
     }
 

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
@@ -69,6 +69,8 @@ public class CIOSearchQueryBuilder {
      */
     var preFilterExpression: String?
 
+    var fmtOptions: [FmtOption]?
+
     /**
      Create a Search request query builder
      
@@ -184,6 +186,6 @@ public class CIOSearchQueryBuilder {
      ```
      */
     public func build() -> CIOSearchQuery {
-        return CIOSearchQuery(query: query, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression)
+        return CIOSearchQuery(query: query, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression, fmtOptions: fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseItemsQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseItemsQuery.swift
@@ -57,6 +57,10 @@ public struct CIOBrowseItemsQuery: CIORequestData {
      */
     var variationsMap: CIOQueryVariationsMap?
     
+    /**
+     The fmt_options to use with the result set
+     Please refer to our docs for more information on available options: https://docs.constructor.com/reference/v1-browse-get-browse-results 
+     */
     public let fmtOptions: [FmtOption]?
 
     /**
@@ -88,7 +92,9 @@ public struct CIOBrowseItemsQuery: CIORequestData {
                          (key: "Nutrition", value: "Natural"),
                          (key: "Brand", value: "Kraft Foods")]
 
-     let browseQuery = CIOBrowseItemsQuery(ids: ["123", "234"], filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"]))
+     let fmtOptions = [("groups_max_depth": "10")]
+
+     let browseQuery = CIOBrowseItemsQuery(ids: ["123", "234"], filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"]), fmtOptions: fmtOptions)
      ```
      */
     public init(ids: [String], filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, fmtOptions: [FmtOption]? = nil) {

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseItemsQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseItemsQuery.swift
@@ -56,6 +56,8 @@ public struct CIOBrowseItemsQuery: CIORequestData {
      The variation map to use with the result set
      */
     var variationsMap: CIOQueryVariationsMap?
+    
+    public let fmtOptions: [FmtOption]?
 
     /**
      The sort method/order for groups
@@ -89,7 +91,7 @@ public struct CIOBrowseItemsQuery: CIORequestData {
      let browseQuery = CIOBrowseItemsQuery(ids: ["123", "234"], filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"]))
      ```
      */
-    public init(ids: [String], filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil) {
+    public init(ids: [String], filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, fmtOptions: [FmtOption]? = nil) {
         self.filters = filters
         self.page = page != nil ? page! : Constants.BrowseQuery.defaultPage
         self.perPage = perPage != nil ? perPage! : Constants.BrowseQuery.defaultPerPage
@@ -100,6 +102,7 @@ public struct CIOBrowseItemsQuery: CIORequestData {
         self.variationsMap = variationsMap
         self.groupsSortOption = groupsSortOption
         self.ids = ids
+        self.fmtOptions = fmtOptions
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -114,5 +117,6 @@ public struct CIOBrowseItemsQuery: CIORequestData {
         requestBuilder.set(variationsMap: self.variationsMap)
         requestBuilder.set(groupsSortOption: self.groupsSortOption)
         requestBuilder.set(ids: self.ids)
+        requestBuilder.set(fmtOptions: self.fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
@@ -74,6 +74,10 @@ public struct CIOBrowseQuery: CIORequestData {
      */
     public let preFilterExpression: String?
     
+    /**
+     The fmt_options to use with the result set
+     Please refer to our docs for more information on available options: https://docs.constructor.com/reference/v1-browse-get-browse-results 
+     */
     public let fmtOptions: [FmtOption]?
 
     func url(with baseURL: String) -> String {
@@ -96,6 +100,7 @@ public struct CIOBrowseQuery: CIORequestData {
         - variationsMap: The variation map to use with the result set
         - groupsSortOption: The sort method/order for groups
         - preFilterExpression: The pre filter expression used to refine results
+        - fmtOptions: The fmt options to use with the result set 
 
      ### Usage Example: ###
      ```
@@ -111,7 +116,9 @@ public struct CIOBrowseQuery: CIORequestData {
         Dtype: "array"
      )
 
-     let browseQuery = CIOBrowseQuery(filterName: "group_id", filterValue: "Pantry", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression)
+     let fmtOptions = [("groups_max_depth": "10")]
+
+     let browseQuery = CIOBrowseQuery(filterName: "group_id", filterValue: "Pantry", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression, fmtOptions: fmtOptions)
      ```
      */
     public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil, fmtOptions: [FmtOption]? = nil) {

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
@@ -73,6 +73,8 @@ public struct CIOBrowseQuery: CIORequestData {
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.com/reference/shared-filter-expressions
      */
     public let preFilterExpression: String?
+    
+    public let fmtOptions: [FmtOption]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.BrowseQuery.format, baseURL, filterName, filterValue)
@@ -112,7 +114,7 @@ public struct CIOBrowseQuery: CIORequestData {
      let browseQuery = CIOBrowseQuery(filterName: "group_id", filterValue: "Pantry", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression)
      ```
      */
-    public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil) {
+    public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil, fmtOptions: [FmtOption]? = nil) {
         self.filterName = filterName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filterValue = filterValue.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filters = filters
@@ -125,6 +127,7 @@ public struct CIOBrowseQuery: CIORequestData {
         self.variationsMap = variationsMap
         self.groupsSortOption = groupsSortOption
         self.preFilterExpression = preFilterExpression
+        self.fmtOptions = fmtOptions
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -139,5 +142,6 @@ public struct CIOBrowseQuery: CIORequestData {
         requestBuilder.set(variationsMap: self.variationsMap)
         requestBuilder.set(groupsSortOption: self.groupsSortOption)
         requestBuilder.set(preFilterExpression: self.preFilterExpression)
+        requestBuilder.set(fmtOptions: self.fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
@@ -68,6 +68,8 @@ public struct CIOSearchQuery: CIORequestData {
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.com/reference/shared-filter-expressions
      */
     public let preFilterExpression: String?
+    
+    public let fmtOptions: [FmtOption]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.SearchQuery.format, baseURL, query)
@@ -105,7 +107,7 @@ public struct CIOSearchQuery: CIORequestData {
      let searchQuery = CIOSearchQuery(query: "red", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression)
      ```
      */
-    public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil) {
+    public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil, fmtOptions: [FmtOption]? = nil) {
         self.query = query.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filters = filters
         self.page = page != nil ? page! : Constants.SearchQuery.defaultPage
@@ -117,6 +119,7 @@ public struct CIOSearchQuery: CIORequestData {
         self.variationsMap = variationsMap
         self.groupsSortOption = groupsSortOption
         self.preFilterExpression = preFilterExpression
+        self.fmtOptions = fmtOptions
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -131,5 +134,6 @@ public struct CIOSearchQuery: CIORequestData {
         requestBuilder.set(variationsMap: self.variationsMap)
         requestBuilder.set(groupsSortOption: self.groupsSortOption)
         requestBuilder.set(preFilterExpression: self.preFilterExpression)
+        requestBuilder.set(fmtOptions: self.fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
@@ -69,6 +69,10 @@ public struct CIOSearchQuery: CIORequestData {
      */
     public let preFilterExpression: String?
     
+    /**
+     The fmt_options to use with the result set
+     Please refer to our docs for more information on available options: https://docs.constructor.com/reference/v1-search-get-search-results
+     */
     public let fmtOptions: [FmtOption]?
 
     func url(with baseURL: String) -> String {
@@ -89,6 +93,7 @@ public struct CIOSearchQuery: CIORequestData {
         - hiddenFacets: The list of hidden facest to return
         - groupsSortOption: The sort method/order for groups
         - preFilterExpression: The pre filter expression used to refine results
+        - fmtOptions: The fmt options to use with the result set 
 
      ### Usage Example: ###
      ```
@@ -103,8 +108,10 @@ public struct CIOSearchQuery: CIORequestData {
         Values: ["price": ValueOption(aggregation: "min", field: "data.price")],
         Dtype: "array"
      )
+
+     let fmtOptions = [("groups_max_depth": "10")]
      
-     let searchQuery = CIOSearchQuery(query: "red", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression)
+     let searchQuery = CIOSearchQuery(query: "red", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression, fmtOptions: fmtOptions)
      ```
      */
     public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil, fmtOptions: [FmtOption]? = nil) {

--- a/AutocompleteClient/FW/Logic/Result/CIOFilterFacet.swift
+++ b/AutocompleteClient/FW/Logic/Result/CIOFilterFacet.swift
@@ -68,16 +68,16 @@ public extension CIOFilterFacet {
         guard let hidden = json["hidden"] as? Bool else { return nil }
 
         let data = json["data"] as? [String: Any] ?? [:]
-        let min = json["min"] as? Int
-        let max = json["max"] as? Int
+        let min = json["min"] as? Double
+        let max = json["max"] as? Double
         let optionsObj = json["options"] as? [JSONObject]
 
         let options: [CIOFilterFacetOption] = optionsObj?.compactMap { obj in return CIOFilterFacetOption(json: obj) } ?? []
 
         self.displayName = displayName
         self.name = name
-        self.min = (min != nil) ? min! : 0
-        self.max = (max != nil) ? max! : 0
+        self.min = min.map(floor).map(Int.init) ?? 0
+        self.max = max.map(ceil).map(Int.init) ?? 0
         self.options = options
         self.type = type
         self.hidden = hidden

--- a/AutocompleteClientTests/FW/Logic/Request/TrackSearchResultClickRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackSearchResultClickRequestBuilder.swift
@@ -97,13 +97,13 @@ class TrackSearchResultClickRequestBuilderTests: XCTestCase {
     func testTrackSearchResultClickBuilder_WithSponsoredListingsParams() {
         let slCampaignOwner = "owner789"
         let slCampaignId = "id123"
-        let tracker = CIOTrackSearchResultClickData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, sectionName: sectionName, slCampaignOwner: slCampaignOwner)
+        let tracker = CIOTrackSearchResultClickData(searchTerm: searchTerm, itemName: itemName, customerID: customerID, sectionName: sectionName, slCampaignID: slCampaignId, slCampaignOwner: slCampaignOwner)
 
         builder.build(trackData: tracker)
         let request = builder.getRequest()
         let url = request.url!.absoluteString
 
         XCTAssertTrue(url.contains("sl_campaign_owner=\(slCampaignOwner)"))
-        XCTAssertTrue(url.contains("sl_campaign_id=\(slCampaignOwner)"))
+        XCTAssertTrue(url.contains("sl_campaign_id=\(slCampaignId)"))
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseItemsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseItemsTests.swift
@@ -102,6 +102,17 @@ class ConstructorIOBrowseItemsTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testBrowseItems_AttachesFmtOptions() {
+        let query = CIOBrowseItemsQuery(ids: ["123", "234"], fmtOptions: [("groups_max_depth", "10")])
+
+        let builder = CIOBuilder(expectation: "Calling BrowseItems with a facet filter should have a facet filter URL query item.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/browse/items?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_max_depth%5D=10&i=\(kRegexClientID)&ids=123&ids=234&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products&\(TestConstants.defaultSegments)"), builder.create())
+
+        self.constructor.browseItems(forQuery: query, completionHandler: { response in })
+        self.wait(for: builder.expectation)
+    }
+
+
     func testBrowseItems_AttachesMultipleFacetFilters() {
         let facetFilters = [(key: "facet1", value: "Organic"),
                             (key: "facet2", value: "Natural"),

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
@@ -90,6 +90,16 @@ class ConstructorIOBrowseTests: XCTestCase {
         self.constructor.browse(forQuery: query, completionHandler: { response in })
         self.wait(for: builder.expectation)
     }
+    
+    func testBrowse_AttachesFmtOptions() {
+        let query = CIOBrowseQuery(filterName: "potato", filterValue: "russet", fmtOptions: [("groups_max_depth", "10")])
+
+        let builder = CIOBuilder(expectation: "Calling Browse with a group filter should have a group_id URL query item.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/browse/potato/russet?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_max_depth%5D=10&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products&\(TestConstants.defaultSegments)"), builder.create())
+
+        self.constructor.browse(forQuery: query, completionHandler: { response in })
+        self.wait(for: builder.expectation)
+    }
 
     func testBrowse_AttachesFacetFilter() {
         let facetFilters = [(key: "facet1", value: "Organic")]

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
@@ -152,6 +152,16 @@ class ConstructorIOSearchTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testSearch_AttachesFmtOptions() {
+        let query = CIOSearchQuery(query: "potato", fmtOptions: [("groups_max_depth", "10")])
+
+        let builder = CIOBuilder(expectation: "Calling Search with a facet filter should have a facet filter URL query item.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/search/potato?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&fmt_options%5Bgroups_max_depth%5D=10&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&num_results_per_page=30&page=1&s=\(kRegexSession)&section=Products&\(TestConstants.defaultSegments)"), builder.create())
+
+        self.constructor.search(forQuery: query, completionHandler: { response in })
+        self.wait(for: builder.expectation)
+    }
+
     func testSearch_AttachesMultipleFacetFilters() {
         let facetFilters = [(key: "facet1", value: "Organic"),
                             (key: "facet2", value: "Natural"),


### PR DESCRIPTION
- There are cases where the response returns min and max not as integers. Example:

```
{
    "display_name": "price_amount",
    "name": "price_amount",
    "data": {},
    "type": "range",
    "hidden": false,
    "status": {},
    "min": 10.22,
    "max": 99.9
}
```

- The current initializer nullifies out min and max if they are not integers, finally resulting in min and max always equal to zero.
- Suggestion: to keep the interface of min and max as integers, first cast them as? Double, then cast to Int using the `floor` value for min and `ceil` value for max.