### PR TITLE
Add parameter `fmtOptions` to CIOBrowseQuery and CIOBrowseItemsQuery initializers

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseItemsQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseItemsQueryBuilder.swift
@@ -62,6 +62,8 @@ public class CIOBrowseItemsQueryBuilder {
      The sort method/order for groups
      */
     var groupsSortOption: CIOGroupsSortOption?
+    
+    var fmtOptions: [FmtOption]?
 
     /**
      Create a Browse Items request query builder
@@ -144,7 +146,12 @@ public class CIOBrowseItemsQueryBuilder {
         self.groupsSortOption = groupsSortOption
         return self
     }
-
+    
+    public func setFmtOptions(_ fmtOptions: [FmtOption]?) ->
+    CIOBrowseItemsQueryBuilder {
+        self.fmtOptions = fmtOptions
+        return self
+    }
     /**
      Build the request object set all of the provided data
      
@@ -167,6 +174,6 @@ public class CIOBrowseItemsQueryBuilder {
      ```
      */
     public func build() -> CIOBrowseItemsQuery {
-        return CIOBrowseItemsQuery(ids: ids, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap)
+        return CIOBrowseItemsQuery(ids: ids, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, fmtOptions: fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOBrowseQueryBuilder.swift
@@ -73,6 +73,8 @@ public class CIOBrowseQueryBuilder {
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.com/reference/shared-filter-expressions
      */
     var preFilterExpression: String?
+    
+    var fmtOptions: [FmtOption]?
 
     /**
      Create a Browse request query builder
@@ -165,6 +167,11 @@ public class CIOBrowseQueryBuilder {
         self.preFilterExpression = preFilterExpression
         return self
     }
+    
+    public func setFmtOptions(_ fmtOptions: [FmtOption]?) -> CIOBrowseQueryBuilder {
+        self.fmtOptions = fmtOptions
+        return self
+    }
 
     /**
      Build the request object set all of the provided data
@@ -191,6 +198,6 @@ public class CIOBrowseQueryBuilder {
      ```
      */
     public func build() -> CIOBrowseQuery {
-        return CIOBrowseQuery(filterName: filterName, filterValue: filterValue, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression)
+        return CIOBrowseQuery(filterName: filterName, filterValue: filterValue, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression, fmtOptions: fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/CIOSearchQueryBuilder.swift
@@ -69,6 +69,8 @@ public class CIOSearchQueryBuilder {
      */
     var preFilterExpression: String?
 
+    var fmtOptions: [FmtOption]?
+
     /**
      Create a Search request query builder
      
@@ -184,6 +186,6 @@ public class CIOSearchQueryBuilder {
      ```
      */
     public func build() -> CIOSearchQuery {
-        return CIOSearchQuery(query: query, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression)
+        return CIOSearchQuery(query: query, filters: filters, sortOption: sortOption, page: page, perPage: perPage, section: section, hiddenFields: hiddenFields, hiddenFacets: hiddenFacets, groupsSortOption: groupsSortOption, variationsMap: variationsMap, preFilterExpression: preFilterExpression, fmtOptions: fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseItemsQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseItemsQuery.swift
@@ -56,6 +56,8 @@ public struct CIOBrowseItemsQuery: CIORequestData {
      The variation map to use with the result set
      */
     var variationsMap: CIOQueryVariationsMap?
+    
+    public let fmtOptions: [FmtOption]?
 
     /**
      The sort method/order for groups
@@ -89,7 +91,7 @@ public struct CIOBrowseItemsQuery: CIORequestData {
      let browseQuery = CIOBrowseItemsQuery(ids: ["123", "234"], filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"]))
      ```
      */
-    public init(ids: [String], filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil) {
+    public init(ids: [String], filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, fmtOptions: [FmtOption]? = nil) {
         self.filters = filters
         self.page = page != nil ? page! : Constants.BrowseQuery.defaultPage
         self.perPage = perPage != nil ? perPage! : Constants.BrowseQuery.defaultPerPage
@@ -100,6 +102,7 @@ public struct CIOBrowseItemsQuery: CIORequestData {
         self.variationsMap = variationsMap
         self.groupsSortOption = groupsSortOption
         self.ids = ids
+        self.fmtOptions = fmtOptions
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -114,5 +117,6 @@ public struct CIOBrowseItemsQuery: CIORequestData {
         requestBuilder.set(variationsMap: self.variationsMap)
         requestBuilder.set(groupsSortOption: self.groupsSortOption)
         requestBuilder.set(ids: self.ids)
+        requestBuilder.set(fmtOptions: self.fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOBrowseQuery.swift
@@ -73,6 +73,8 @@ public struct CIOBrowseQuery: CIORequestData {
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.com/reference/shared-filter-expressions
      */
     public let preFilterExpression: String?
+    
+    public let fmtOptions: [FmtOption]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.BrowseQuery.format, baseURL, filterName, filterValue)
@@ -112,7 +114,7 @@ public struct CIOBrowseQuery: CIORequestData {
      let browseQuery = CIOBrowseQuery(filterName: "group_id", filterValue: "Pantry", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression)
      ```
      */
-    public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil) {
+    public init(filterName: String, filterValue: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil, fmtOptions: [FmtOption]? = nil) {
         self.filterName = filterName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filterValue = filterValue.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filters = filters
@@ -125,6 +127,7 @@ public struct CIOBrowseQuery: CIORequestData {
         self.variationsMap = variationsMap
         self.groupsSortOption = groupsSortOption
         self.preFilterExpression = preFilterExpression
+        self.fmtOptions = fmtOptions
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -139,5 +142,6 @@ public struct CIOBrowseQuery: CIORequestData {
         requestBuilder.set(variationsMap: self.variationsMap)
         requestBuilder.set(groupsSortOption: self.groupsSortOption)
         requestBuilder.set(preFilterExpression: self.preFilterExpression)
+        requestBuilder.set(fmtOptions: self.fmtOptions)
     }
 }

--- a/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOSearchQuery.swift
@@ -68,6 +68,8 @@ public struct CIOSearchQuery: CIORequestData {
      Please refer to our docs for the syntax on adding pre filter expressions: https://docs.constructor.com/reference/shared-filter-expressions
      */
     public let preFilterExpression: String?
+    
+    public let fmtOptions: [FmtOption]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.SearchQuery.format, baseURL, query)
@@ -105,7 +107,7 @@ public struct CIOSearchQuery: CIORequestData {
      let searchQuery = CIOSearchQuery(query: "red", filters: CIOQueryFilters(groupFilter: nil, facetFilters: facetFilters), page: 1, perPage: 30, section: "Products", hiddenFields: ["price_CA", "currency_CA"], hiddenFacets: ["brand", "price_CA"], variationsMap: variationsMap, preFilterExpression: preFilterExpression)
      ```
      */
-    public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil) {
+    public init(query: String, filters: CIOQueryFilters? = nil, sortOption: CIOSortOption? = nil, page: Int? = nil, perPage: Int? = nil, section: String? = nil, hiddenFields: [String]? = nil, hiddenFacets: [String]? = nil, groupsSortOption: CIOGroupsSortOption? = nil, variationsMap: CIOQueryVariationsMap? = nil, preFilterExpression: String? = nil, fmtOptions: [FmtOption]? = nil) {
         self.query = query.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
         self.filters = filters
         self.page = page != nil ? page! : Constants.SearchQuery.defaultPage
@@ -117,6 +119,7 @@ public struct CIOSearchQuery: CIORequestData {
         self.variationsMap = variationsMap
         self.groupsSortOption = groupsSortOption
         self.preFilterExpression = preFilterExpression
+        self.fmtOptions = fmtOptions
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -131,5 +134,6 @@ public struct CIOSearchQuery: CIORequestData {
         requestBuilder.set(variationsMap: self.variationsMap)
         requestBuilder.set(groupsSortOption: self.groupsSortOption)
         requestBuilder.set(preFilterExpression: self.preFilterExpression)
+        requestBuilder.set(fmtOptions: self.fmtOptions)
     }
 }


### PR DESCRIPTION
- The `mftOptions`, where `groups_max_depth` can be set are missing in the `CIOBrowseQuery` initializer: https://constructor-io.github.io/constructorio-client-swift/Structs/CIOBrowseQuery.html
- Without `groups_max_depth` settings, the default value is 1 and thus the groups in the response has only one level of groups, where the client can get the items count for each group. Clients cannot get items count for children groups.
- In the mean time, the Android SDK has `fmtOptions` as parameters in the constructor: https://constructor-io.github.io/constructorio-client-android/library/io.constructor.data.builder/-browse-request/index.html
- Suggestion: Add `fmtOptions` to the CIOBrowseQuery initializer, similar as in Android SDK, and decorate the RequestBuilder accordingly.
- Same issue with `CIOBrowseItemsQuery`.