### PR TITLE
Reuse CIOBrowseResponse and BrowseResponseParser from outside of the SDK

### DIFF
--- a/AutocompleteClient/FW/API/Parser/Browse/BrowseResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Browse/BrowseResponseParser.swift
@@ -10,11 +10,18 @@ import Foundation
 
 class BrowseResponseParser: AbstractBrowseResponseParser {
     func parse(browseResponseData: Data) throws -> CIOBrowseResponse {
-
         do {
             let json = try JSONSerialization.jsonObject(with: browseResponseData) as? JSONObject
-
-            guard let response = json?["response"] as? JSONObject else {
+            
+            return try jsonObjectToCIOBrowseResponse(dictionary: json)
+        } catch {
+            throw CIOError(errorType: .invalidResponse)
+        }
+    }
+    
+    func jsonObjectToCIOBrowseResponse(dictionary: JSONObject?) throws -> CIOBrowseResponse {
+        do {
+            guard let response = dictionary?["response"] as? JSONObject else {
                 throw CIOError(errorType: .invalidResponse)
             }
 
@@ -30,11 +37,11 @@ class BrowseResponseParser: AbstractBrowseResponseParser {
             let groups: [CIOFilterGroup] = groupsObj?.compactMap({ obj  in return CIOFilterGroup(json: obj) }) ?? []
             let totalNumResults = response["total_num_results"] as? Int ?? 0
             let collection: CIOCollectionData? = CIOCollectionData(json: response["collection"] as? JSONObject)
-            let resultID = json?["result_id"] as? String ?? ""
+            let resultID = dictionary?["result_id"] as? String ?? ""
             let resultSources: CIOResultSources? = CIOResultSources(json: response["result_sources"] as? JSONObject)
             let refinedContent: [CIORefinedContent] = refinedContentObj?.compactMap({ obj in return CIORefinedContent(json: obj) }) ?? []
 
-            guard let request: JSONObject = json?["request"] as? JSONObject else {
+            guard let request: JSONObject = dictionary?["request"] as? JSONObject else {
                 throw CIOError(errorType: .invalidResponse)
             }
 
@@ -53,6 +60,5 @@ class BrowseResponseParser: AbstractBrowseResponseParser {
         } catch {
             throw CIOError(errorType: .invalidResponse)
         }
-
     }
 }

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOBrowseResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOBrowseResponse.swift
@@ -62,3 +62,9 @@ public struct CIOBrowseResponse {
      */
     public var request: JSONObject
 }
+
+extension CIOBrowseResponse {
+    public static func response(from JSON: JSONObject) throws -> Self {
+        try BrowseResponseParser().jsonObjectToCIOBrowseResponse(dictionary: JSON)
+    }
+}


### PR DESCRIPTION
Due to tight coupling of the legacy code base and CIOBrowseResponse data type there is a need to use CIOBrowseResponse and SDK internal BrowseResponseParser for decoding custom endpoint response. This response has the field with the same structure as CIOBrowseResponse. In order to achieve that the following changes were introduced:
- parse(browseResponseData: Data) throws -> CIOBrowseResponse inside BrowseResponseParser was split into two functions. The first one expects Data and converts that into JSONObject of type [String: Any]. The second one expects JSONObject and return CIOBrowse response. 
- CIOBrowseResponse was extended with a static constructor, which receives JSONObject and calls - jsonObjectToCIOBrowseResponse(dictionary: JSONObject?) and returns CIOBrowseResponse. 

Original flow calls the first task and then the second one, returning the result of the second.
Custom flow is calling the second one, re-using parser logic and waiting for the CIOBrowseResponse.