### PR TITLE
[CDX-386] Add seed item ids to rex events

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultClickData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultClickData.swift
@@ -24,12 +24,13 @@ struct CIOTrackRecommendationResultClickData: CIORequestData {
     let sectionName: String?
     let resultID: String?
     let analyticsTags: [String: String]?
+    let seedItemIds: [String]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackRecommendationResultClick.format, baseURL)
     }
 
-    init(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil) {
+    init(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil) {
         self.podID = podID
         self.strategyID = strategyID
         self.customerID = customerID
@@ -41,6 +42,7 @@ struct CIOTrackRecommendationResultClickData: CIORequestData {
         self.sectionName = sectionName
         self.resultID = resultID
         self.analyticsTags = analyticsTags
+        self.seedItemIds = seedItemIds
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {}
@@ -81,6 +83,9 @@ struct CIOTrackRecommendationResultClickData: CIORequestData {
         }
         if (self.analyticsTags != nil) {
             dict["analytics_tags"] = self.analyticsTags
+        }
+        if let seedItemIds = self.seedItemIds, !seedItemIds.isEmpty {
+            dict["seed_item_ids"] = seedItemIds
         }
 
         dict["beacon"] = true

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultClickData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultClickData.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- Struct encapsulating the parameters that must/can be set set in order to track browse result click
+ Struct encapsulating the parameters that should be set in order to track recommendations result click
  */
 struct CIOTrackRecommendationResultClickData: CIORequestData {
 
@@ -24,13 +24,13 @@ struct CIOTrackRecommendationResultClickData: CIORequestData {
     let sectionName: String?
     let resultID: String?
     let analyticsTags: [String: String]?
-    let seedItemIds: [String]?
+    let seedItemIDs: [String]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackRecommendationResultClick.format, baseURL)
     }
 
-    init(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil) {
+    init(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil) {
         self.podID = podID
         self.strategyID = strategyID
         self.customerID = customerID
@@ -42,7 +42,7 @@ struct CIOTrackRecommendationResultClickData: CIORequestData {
         self.sectionName = sectionName
         self.resultID = resultID
         self.analyticsTags = analyticsTags
-        self.seedItemIds = seedItemIds
+        self.seedItemIDs = seedItemIDs
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {}
@@ -84,8 +84,8 @@ struct CIOTrackRecommendationResultClickData: CIORequestData {
         if (self.analyticsTags != nil) {
             dict["analytics_tags"] = self.analyticsTags
         }
-        if let seedItemIds = self.seedItemIds, !seedItemIds.isEmpty {
-            dict["seed_item_ids"] = seedItemIds
+        if let seedItemIDs = self.seedItemIDs, !seedItemIDs.isEmpty {
+            dict["seed_item_ids"] = seedItemIDs
         }
 
         dict["beacon"] = true

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- Struct encapsulating the parameters that must/can be set set in order to track browse result click
+ Struct encapsulating the parameters that should be set in order to track recommendation results view
  */
 struct CIOTrackRecommendationResultsViewData: CIORequestData {
 
@@ -22,13 +22,13 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
     let resultID: String?
     let customerIDs: [String]?
     let analyticsTags: [String: String]?
-    let seedItemIds: [String]?
+    let seedItemIDs: [String]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackRecommendationResultsView.format, baseURL)
     }
 
-    init(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, url: String = "Not Available", analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil) {
+    init(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, url: String = "Not Available", analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil) {
         self.podID = podID
         self.url = url
         self.numResultsViewed = numResultsViewed
@@ -38,7 +38,7 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
         self.resultID = resultID
         self.customerIDs = customerIDs
         self.analyticsTags = analyticsTags
-        self.seedItemIds = seedItemIds
+        self.seedItemIDs = seedItemIDs
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {}
@@ -75,8 +75,8 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
         if (self.analyticsTags != nil) {
             dict["analytics_tags"] = self.analyticsTags
         }
-        if let seedItemIds = self.seedItemIds, !seedItemIds.isEmpty {
-            dict["seed_item_ids"] = seedItemIds
+        if let seedItemIDs = self.seedItemIDs, !seedItemIDs.isEmpty {
+            dict["seed_item_ids"] = seedItemIDs
         }
 
         dict["beacon"] = true

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
@@ -22,12 +22,13 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
     let resultID: String?
     let customerIDs: [String]?
     let analyticsTags: [String: String]?
+    let seedItemIds: [String]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackRecommendationResultsView.format, baseURL)
     }
 
-    init(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, url: String = "Not Available", analyticsTags: [String: String]? = nil) {
+    init(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, url: String = "Not Available", analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil) {
         self.podID = podID
         self.url = url
         self.numResultsViewed = numResultsViewed
@@ -37,6 +38,7 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
         self.resultID = resultID
         self.customerIDs = customerIDs
         self.analyticsTags = analyticsTags
+        self.seedItemIds = seedItemIds
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {}
@@ -72,6 +74,9 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
        }
         if (self.analyticsTags != nil) {
             dict["analytics_tags"] = self.analyticsTags
+        }
+        if let seedItemIds = self.seedItemIds, !seedItemIds.isEmpty {
+            dict["seed_item_ids"] = seedItemIds
         }
 
         dict["beacon"] = true

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -544,16 +544,17 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         - sectionName: The name of the autocomplete section the term came from
         - resultID: Identifier of result set
         - analyticsTags Additional analytics tags to pass
+        - seedItemIds: The seed item ID(s) used to generate recommendations
         - completionHandler: The callback to execute on completion.
-     
+
      ### Usage Example: ###
      ```
-     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
+     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIds: ["seed-item-123"])
      ```
      */
-    public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIds: seedItemIds)
 
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
@@ -574,16 +575,17 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         - sectionName The name of the autocomplete section the term came from
         - resultID: Identifier of result set
         - analyticsTags Additional analytics tags to pass
+        - seedItemIds: The seed item ID(s) used to generate recommendations
         - completionHandler: The callback to execute on completion.
-     
+
      ### Usage Example: ###
      ```
-     constructorIO.trackRecommendationResultClick(podID: "pdp_best_sellers", strategyID: "best_sellers", customerID: "P183021", variationID: "7281930", numResultsPerPage: 30, resultPage: 1, resultCount: 15, resultPositionOnPage: 1, resultID: "179b8a0e-3799-4a31-be87-127b06871de2")
+     constructorIO.trackRecommendationResultClick(podID: "pdp_best_sellers", strategyID: "best_sellers", customerID: "P183021", variationID: "7281930", numResultsPerPage: 30, resultPage: 1, resultCount: 15, resultPositionOnPage: 1, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIds: ["seed-item-123"])
      ```
      */
-    public func trackRecommendationResultClick(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackRecommendationResultClick(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultClickData(podID: podID, strategyID: strategyID, customerID: customerID, variationID: variationID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackRecommendationResultClickData(podID: podID, strategyID: strategyID, customerID: customerID, variationID: variationID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIds: seedItemIds)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -539,22 +539,22 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         - podID: The pod ID
         - numResultsViewed: The count of results that is visible to the user
         - customerIDs: The items that were loaded
-        - resultPage: The current page that recommedantion result is on
+        - resultPage: The current page that recommendation result is on
         - resultCount: The total number of recommendation results
         - sectionName: The name of the autocomplete section the term came from
         - resultID: Identifier of result set
         - analyticsTags: Additional analytics tags to pass
-        - seedItemIds: The seed item ID(s) used to generate recommendations
+        - seedItemIDs: The item ID(s) used as seeds when generating recommendations for this pod
         - completionHandler: The callback to execute on completion.
 
      ### Usage Example: ###
      ```
-     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIds: ["seed-item-123"])
+     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
      ```
      */
-    public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIds: seedItemIds)
+        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIDs: seedItemIDs)
 
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
@@ -569,23 +569,23 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         - customerID: The item ID
         - variationID: The item variation ID
         - numResultsPerPage: The count of recommendation results on each page
-        - resultPage: The current page that recommedantion result is on
+        - resultPage: The current page that recommendation result is on
         - resultCount: The total number of recommendation results
         - resultPositionOnPage: The position of the recommendation result that was clicked on
         - sectionName: The name of the autocomplete section the term came from
         - resultID: Identifier of result set
         - analyticsTags: Additional analytics tags to pass
-        - seedItemIds: The seed item ID(s) used to generate recommendations
+        - seedItemIDs: The item ID(s) used as seeds when generating recommendations for this pod
         - completionHandler: The callback to execute on completion.
 
      ### Usage Example: ###
      ```
-     constructorIO.trackRecommendationResultClick(podID: "pdp_best_sellers", strategyID: "best_sellers", customerID: "P183021", variationID: "7281930", numResultsPerPage: 30, resultPage: 1, resultCount: 15, resultPositionOnPage: 1, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIds: ["seed-item-123"])
+     constructorIO.trackRecommendationResultClick(podID: "pdp_best_sellers", strategyID: "best_sellers", customerID: "P183021", variationID: "7281930", numResultsPerPage: 30, resultPage: 1, resultCount: 15, resultPositionOnPage: 1, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
      ```
      */
-    public func trackRecommendationResultClick(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIds: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackRecommendationResultClick(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultClickData(podID: podID, strategyID: strategyID, customerID: customerID, variationID: variationID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIds: seedItemIds)
+        let data = CIOTrackRecommendationResultClickData(podID: podID, strategyID: strategyID, customerID: customerID, variationID: variationID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIDs: seedItemIDs)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationResultClickRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationResultClickRequestBuilder.swift
@@ -60,35 +60,35 @@ class TrackRecommendationResultClickRequestBuilder: XCTestCase {
         XCTAssertEqual(analyticsTagsPayload, analyticsTags)
     }
 
-    func testTrackRecommendationResultClickBuilder_WithSingleSeedItemId() {
-        let seedItemIds = ["seed-item-123"]
-        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+    func testTrackRecommendationResultClickBuilder_WithSingleSeedItemID() {
+        let seedItemIDs = ["seed-item-123"]
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIDs: seedItemIDs)
         builder.build(trackData: recommendationClickData)
         let request = builder.getRequest()
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
-        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+        let loadedSeedItemIDs = payload?["seed_item_ids"] as? [String] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(loadedSeedItemIds.count, 1)
-        XCTAssertEqual(loadedSeedItemIds[0], seedItemIds[0])
+        XCTAssertEqual(loadedSeedItemIDs.count, 1)
+        XCTAssertEqual(loadedSeedItemIDs[0], seedItemIDs[0])
     }
 
-    func testTrackRecommendationResultClickBuilder_WithMultipleSeedItemIds() {
-        let seedItemIds = ["seed-item-123", "seed-item-456", "seed-item-789"]
-        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+    func testTrackRecommendationResultClickBuilder_WithMultipleSeedItemIDs() {
+        let seedItemIDs = ["seed-item-123", "seed-item-456", "seed-item-789"]
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIDs: seedItemIDs)
         builder.build(trackData: recommendationClickData)
         let request = builder.getRequest()
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
-        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+        let loadedSeedItemIDs = payload?["seed_item_ids"] as? [String] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(loadedSeedItemIds.count, 3)
-        XCTAssertEqual(loadedSeedItemIds, seedItemIds)
+        XCTAssertEqual(loadedSeedItemIDs.count, 3)
+        XCTAssertEqual(loadedSeedItemIDs, seedItemIDs)
     }
 
-    func testTrackRecommendationResultClickBuilder_WithEmptySeedItemIds() {
-        let seedItemIds: [String] = []
-        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+    func testTrackRecommendationResultClickBuilder_WithEmptySeedItemIDs() {
+        let seedItemIDs: [String] = []
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIDs: seedItemIDs)
         builder.build(trackData: recommendationClickData)
         let request = builder.getRequest()
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationResultClickRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationResultClickRequestBuilder.swift
@@ -69,8 +69,7 @@ class TrackRecommendationResultClickRequestBuilder: XCTestCase {
         let loadedSeedItemIDs = payload?["seed_item_ids"] as? [String] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(loadedSeedItemIDs.count, 1)
-        XCTAssertEqual(loadedSeedItemIDs[0], seedItemIDs[0])
+        XCTAssertEqual(loadedSeedItemIDs, seedItemIDs)
     }
 
     func testTrackRecommendationResultClickBuilder_WithMultipleSeedItemIDs() {
@@ -84,6 +83,16 @@ class TrackRecommendationResultClickRequestBuilder: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(loadedSeedItemIDs.count, 3)
         XCTAssertEqual(loadedSeedItemIDs, seedItemIDs)
+    }
+
+    func testTrackRecommendationResultClickBuilder_WithNilSeedItemIDs() {
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIDs: nil)
+        builder.build(trackData: recommendationClickData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNil(payload?["seed_item_ids"], "Nil seed_item_ids should not be included in the payload")
     }
 
     func testTrackRecommendationResultClickBuilder_WithEmptySeedItemIDs() {

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationResultClickRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationResultClickRequestBuilder.swift
@@ -59,4 +59,41 @@ class TrackRecommendationResultClickRequestBuilder: XCTestCase {
         XCTAssertEqual(payload?["result_position_on_page"] as? Int, resultPositionOnPage)
         XCTAssertEqual(analyticsTagsPayload, analyticsTags)
     }
+
+    func testTrackRecommendationResultClickBuilder_WithSingleSeedItemId() {
+        let seedItemIds = ["seed-item-123"]
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+        builder.build(trackData: recommendationClickData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedSeedItemIds.count, 1)
+        XCTAssertEqual(loadedSeedItemIds[0], seedItemIds[0])
+    }
+
+    func testTrackRecommendationResultClickBuilder_WithMultipleSeedItemIds() {
+        let seedItemIds = ["seed-item-123", "seed-item-456", "seed-item-789"]
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+        builder.build(trackData: recommendationClickData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedSeedItemIds.count, 3)
+        XCTAssertEqual(loadedSeedItemIds, seedItemIds)
+    }
+
+    func testTrackRecommendationResultClickBuilder_WithEmptySeedItemIds() {
+        let seedItemIds: [String] = []
+        let recommendationClickData = CIOTrackRecommendationResultClickData(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+        builder.build(trackData: recommendationClickData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNil(payload?["seed_item_ids"], "Empty seed_item_ids should not be included in the payload")
+    }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -69,35 +69,35 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(loadedItems[0]["item_id"], customerIDs[0])
     }
 
-    func testTrackRecommendationResultsViewBuilder_WithSingleSeedItemId() {
-        let seedItemIds = ["seed-item-123"]
-        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIds: seedItemIds)
+    func testTrackRecommendationResultsViewBuilder_WithSingleSeedItemID() {
+        let seedItemIDs = ["seed-item-123"]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIDs: seedItemIDs)
         builder.build(trackData: recommendationViewData)
         let request = builder.getRequest()
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
-        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+        let loadedSeedItemIDs = payload?["seed_item_ids"] as? [String] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(loadedSeedItemIds.count, 1)
-        XCTAssertEqual(loadedSeedItemIds[0], seedItemIds[0])
+        XCTAssertEqual(loadedSeedItemIDs.count, 1)
+        XCTAssertEqual(loadedSeedItemIDs[0], seedItemIDs[0])
     }
 
-    func testTrackRecommendationResultsViewBuilder_WithMultipleSeedItemIds() {
-        let seedItemIds = ["seed-item-123", "seed-item-456", "seed-item-789"]
-        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIds: seedItemIds)
+    func testTrackRecommendationResultsViewBuilder_WithMultipleSeedItemIDs() {
+        let seedItemIDs = ["seed-item-123", "seed-item-456", "seed-item-789"]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIDs: seedItemIDs)
         builder.build(trackData: recommendationViewData)
         let request = builder.getRequest()
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
-        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+        let loadedSeedItemIDs = payload?["seed_item_ids"] as? [String] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(loadedSeedItemIds.count, 3)
-        XCTAssertEqual(loadedSeedItemIds, seedItemIds)
+        XCTAssertEqual(loadedSeedItemIDs.count, 3)
+        XCTAssertEqual(loadedSeedItemIDs, seedItemIDs)
     }
 
-    func testTrackRecommendationResultsViewBuilder_WithEmptySeedItemIds() {
-        let seedItemIds: [String] = []
-        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIds: seedItemIds)
+    func testTrackRecommendationResultsViewBuilder_WithEmptySeedItemIDs() {
+        let seedItemIDs: [String] = []
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIDs: seedItemIDs)
         builder.build(trackData: recommendationViewData)
         let request = builder.getRequest()
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -68,4 +68,41 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(loadedItems.count, 3)
         XCTAssertEqual(loadedItems[0]["item_id"], customerIDs[0])
     }
+
+    func testTrackRecommendationResultsViewBuilder_WithSingleSeedItemId() {
+        let seedItemIds = ["seed-item-123"]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIds: seedItemIds)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedSeedItemIds.count, 1)
+        XCTAssertEqual(loadedSeedItemIds[0], seedItemIds[0])
+    }
+
+    func testTrackRecommendationResultsViewBuilder_WithMultipleSeedItemIds() {
+        let seedItemIds = ["seed-item-123", "seed-item-456", "seed-item-789"]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIds: seedItemIds)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedSeedItemIds = payload?["seed_item_ids"] as? [String] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedSeedItemIds.count, 3)
+        XCTAssertEqual(loadedSeedItemIds, seedItemIds)
+    }
+
+    func testTrackRecommendationResultsViewBuilder_WithEmptySeedItemIds() {
+        let seedItemIds: [String] = []
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIds: seedItemIds)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNil(payload?["seed_item_ids"], "Empty seed_item_ids should not be included in the payload")
+    }
 }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -78,8 +78,7 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         let loadedSeedItemIDs = payload?["seed_item_ids"] as? [String] ?? []
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(loadedSeedItemIDs.count, 1)
-        XCTAssertEqual(loadedSeedItemIDs[0], seedItemIDs[0])
+        XCTAssertEqual(loadedSeedItemIDs, seedItemIDs)
     }
 
     func testTrackRecommendationResultsViewBuilder_WithMultipleSeedItemIDs() {
@@ -93,6 +92,16 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(loadedSeedItemIDs.count, 3)
         XCTAssertEqual(loadedSeedItemIDs, seedItemIDs)
+    }
+
+    func testTrackRecommendationResultsViewBuilder_WithNilSeedItemIDs() {
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIDs: nil)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNil(payload?["seed_item_ids"], "Nil seed_item_ids should not be included in the payload")
     }
 
     func testTrackRecommendationResultsViewBuilder_WithEmptySeedItemIDs() {

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
@@ -14,7 +14,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
 
     fileprivate let unitTestKey = "key_vM4GkLckwiuxwyRA"
     fileprivate let session = 90
-    fileprivate let quizVersionID = "5334fed4-7a54-4049-b609-e9d3d3f39591"
+    fileprivate let quizVersionID = "cc8a9dac-d337-4dbc-bbf7-48469c0de7af"
     fileprivate let quizSessionID = "session-id"
     fileprivate let sectionName = "Products"
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackAutocompleteSelectTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackAutocompleteSelectTests.swift
@@ -54,7 +54,7 @@ class ConstructorIOTrackAutocompleteSelectTests: XCTestCase {
         let itemID = "0123456789"
         let builder = CIOBuilder(expectation: "Calling trackAutocompleteSelect should send a valid request.", builder: http(200))
 
-        stub(regex("https://ac.cnstrc.com/autocomplete/corn/select?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&original_query=co&item_id=0123456789&s=\(kRegexSession)&section=Search%20Suggestions&tr=click&\(TestConstants.defaultSegments)"), builder.create())
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/select?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&item_id=0123456789&key=\(kRegexAutocompleteKey)&original_query=co&s=\(kRegexSession)&section=Search%20Suggestions&tr=click&\(TestConstants.defaultSegments)"), builder.create())
         self.constructor.trackAutocompleteSelect(searchTerm: searchTerm, originalQuery: searchOriginalQuery, sectionName: searchSectionName, itemID: itemID)
         self.wait(for: builder.expectation)
     }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultClickTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultClickTests.swift
@@ -117,15 +117,15 @@ class ConstructorIOTrackRecommendationResultClickTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testTrackRecommendationResultClick_WithSeedItemIds() {
+    func testTrackRecommendationResultClick_WithSeedItemIDs() {
         let podID = "item_page_1"
         let customerID = "customerID123"
-        let seedItemIds = ["seed-item-123", "seed-item-456"]
+        let seedItemIDs = ["seed-item-123", "seed-item-456"]
 
         let builder = CIOBuilder(expectation: "Calling trackRecommendationResultClick should send a valid request with seed item IDs.", builder: http(200))
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/recommendation_result_click?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
 
-        self.constructor.trackRecommendationResultClick(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+        self.constructor.trackRecommendationResultClick(podID: podID, customerID: customerID, seedItemIDs: seedItemIDs)
         self.wait(for: builder.expectation)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultClickTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultClickTests.swift
@@ -116,4 +116,16 @@ class ConstructorIOTrackRecommendationResultClickTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
+
+    func testTrackRecommendationResultClick_WithSeedItemIds() {
+        let podID = "item_page_1"
+        let customerID = "customerID123"
+        let seedItemIds = ["seed-item-123", "seed-item-456"]
+
+        let builder = CIOBuilder(expectation: "Calling trackRecommendationResultClick should send a valid request with seed item IDs.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/recommendation_result_click?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+
+        self.constructor.trackRecommendationResultClick(podID: podID, customerID: customerID, seedItemIds: seedItemIds)
+        self.wait(for: builder.expectation)
+    }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
@@ -111,14 +111,14 @@ class ConstructorIOTrackRecommendationResultsViewTests: XCTestCase {
         self.wait(for: expectation)
     }
 
-    func testTrackRecommendationResultsView_WithSeedItemIds() {
+    func testTrackRecommendationResultsView_WithSeedItemIDs() {
         let podID = "item_page_1"
-        let seedItemIds = ["seed-item-123", "seed-item-456"]
+        let seedItemIDs = ["seed-item-123", "seed-item-456"]
 
         let builder = CIOBuilder(expectation: "Calling trackRecommendationResultsView should send a valid request with seed item IDs.", builder: http(200))
         stub(regex("https://ac.cnstrc.com/v2/behavioral_action/recommendation_result_view?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
 
-        self.constructor.trackRecommendationResultsView(podID: podID, seedItemIds: seedItemIds)
+        self.constructor.trackRecommendationResultsView(podID: podID, seedItemIDs: seedItemIDs)
         self.wait(for: builder.expectation)
     }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
@@ -110,4 +110,15 @@ class ConstructorIOTrackRecommendationResultsViewTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
+
+    func testTrackRecommendationResultsView_WithSeedItemIds() {
+        let podID = "item_page_1"
+        let seedItemIds = ["seed-item-123", "seed-item-456"]
+
+        let builder = CIOBuilder(expectation: "Calling trackRecommendationResultsView should send a valid request with seed item IDs.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/recommendation_result_view?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+
+        self.constructor.trackRecommendationResultsView(podID: podID, seedItemIds: seedItemIds)
+        self.wait(for: builder.expectation)
+    }
 }


### PR DESCRIPTION
Adds support for `seedItemIds` for recommendation events:
- `trackRecommendationResultClick `
- `trackRecommendationResultsView`