### PR TITLE
[NOCDX] Fix tests

### DIFF
--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOAutocompleteTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOAutocompleteTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOAutocompleteTests: XCTestCase {
@@ -16,6 +17,11 @@ class ConstructorIOAutocompleteTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.constructor = TestConstants.testConstructor()
+    }
+
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
     }
 
     func testAutocomplete_With200() {

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseFacetOptionsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseFacetOptionsTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOBrowseFacetOptionsTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOBrowseFacetOptionsTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseFacetsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseFacetsTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOBrowseFacetsTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOBrowseFacetsTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseGroupsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseGroupsTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOBrowseGroupsTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOBrowseGroupsTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseItemsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseItemsTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOBrowseItemsTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOBrowseItemsTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOBrowseTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOBrowseTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOBrowseTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizIntegrationTests.swift
@@ -128,7 +128,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithSingleTypeUsingSingleAnswer() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
@@ -158,7 +158,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithSingleTypeUsingWrongAnswerType() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1", "2"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1", "2"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -173,7 +173,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithMultipleTypeUsingMultipleAnswer() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
@@ -197,7 +197,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithMultipleTypeUsingWrongAnswerType() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["true"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["true"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -212,7 +212,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithCoverTypeUsingCoverAnswer() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["seen"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["seen"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
@@ -237,7 +237,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizNextQuestion_WithCoverTypeUsingWrongAnswerType() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizNextQuestion(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
 
@@ -252,7 +252,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizResults() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"], ["seen"]])
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["seen"], ["true"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizResults(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!
@@ -276,7 +276,7 @@ class ConstructorIOQuizIntegrationTests: XCTestCase {
     func testGetQuizResults_WithVersionIDAndSessionID() {
         let constructorClient = ConstructorIO(config: ConstructorIOConfig(apiKey: unitTestKey))
         let expectation = XCTestExpectation(description: "Request 200")
-        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["true"], ["seen"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
+        let query = CIOQuizQuery(quizID: "test-quiz", answers: [["1"], ["1", "2"], ["seen"], ["true"]], quizVersionID: self.quizVersionID, quizSessionID: self.quizSessionID)
         constructorClient.getQuizResults(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             let responseData = response.data!

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOQuizTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOQuizTests: XCTestCase {
@@ -21,7 +22,7 @@ class ConstructorIOQuizTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 
@@ -78,14 +79,14 @@ class ConstructorIOQuizTests: XCTestCase {
         })
         self.wait(for: expectation)
     }
-    
+
     func testQuizResults_WithValidRequest_ReturnsNonNilResponseWithRequestObject() {
         let expectation = self.expectation(description: "Calling Quiz Results with valid parameters should return a non-nil response with the request object.")
 
         let query = CIOQuizQuery(quizID: "test-quiz", answers: [["2"], ["2, 3"]])
 
         let dataToReturn = TestResource.load(name: TestResource.Response.quizResultsJSONFilename)
-        stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=2&a=2,3&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), http(200, data: dataToReturn))
+        stub(regex("https://quizzes.cnstrc.com/v1/quizzes/test-quiz/results?_dt=\(kRegexTimestamp)&a=2&a=2,%203&c=\(kRegexVersion)&i=\(kRegexClientID)&key=ZqXaOfXuBWD4s3XzCI1q&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), http(200, data: dataToReturn))
 
         self.constructor.getQuizResults(forQuery: query, completionHandler: { response in
             XCTAssertNotNil(response.data?.results, "Calling Quiz Results next with valid parameters should return a non-nil response with request object")

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIORecommendationsTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIORecommendationsTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIORecommendationsTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIORecommendationsTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOSearchTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOSearchTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOSearchTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOUserIDTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOUserIDTests.swift
@@ -7,6 +7,7 @@
 //
 
 import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOUserIDTests: XCTestCase {
@@ -17,6 +18,11 @@ class ConstructorIOUserIDTests: XCTestCase {
         super.setUp()
         self.constructor = TestConstants.testConstructor()
         self.constructor.userID = "abcdefg"
+    }
+
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
     }
 
     func testAutocomplete() {

--- a/AutocompleteClientTests/FW/Logic/Worker/SearchTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/SearchTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import ConstructorAutocomplete
+import OHHTTPStubs
 import XCTest
 
 class ConstructorIOSearchTests: XCTestCase {
@@ -19,7 +20,7 @@ class ConstructorIOSearchTests: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 


### PR DESCRIPTION
**Title**
Fix tests by properly cleaning up HTTP stubs and correcting quiz integration tests.

**Summary**
  - Add `OHHTTPStubs.removeAllStubs()` in `tearDown()` across all test files to prevent stub leakage between tests
  - Add missing `tearDown()` methods in `ConstructorIOAutocompleteTests` and `ConstructorIOUserIDTests`
  - Fix quiz integration tests to pass `quizVersionID` and `quizSessionID` parameters and correct answer ordering
  - Fix URL encoding in quiz results stub regex (`"2, 3"` → `"2,%203"`)