### PR TITLE
Add items param to trackRecommendationResultsView for variation ID su…

### DIFF
--- a/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackRecommendationResultsViewData.swift
@@ -23,12 +23,13 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
     let customerIDs: [String]?
     let analyticsTags: [String: String]?
     let seedItemIDs: [String]?
+    let items: [CIOItem]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackRecommendationResultsView.format, baseURL)
     }
 
-    init(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, url: String = "Not Available", analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil) {
+    init(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, url: String = "Not Available", analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, items: [CIOItem]? = nil) {
         self.podID = podID
         self.url = url
         self.numResultsViewed = numResultsViewed
@@ -39,6 +40,7 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
         self.customerIDs = customerIDs
         self.analyticsTags = analyticsTags
         self.seedItemIDs = seedItemIDs
+        self.items = items
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {}
@@ -68,10 +70,25 @@ struct CIOTrackRecommendationResultsViewData: CIORequestData {
         if self.resultID != nil {
             dict["result_id"] = self.resultID
         }
-        if let loadedCustomerIDs = self.customerIDs {
-            let items = loadedCustomerIDs.map { ["item_id": $0] }
-            dict["items"] = items
-       }
+        if let providedItems = self.items {
+            let itemsArray = providedItems.map { item -> [String: String] in
+                var obj: [String: String] = ["item_id": item.customerID]
+                if let variationID = item.variationID {
+                    obj["variation_id"] = variationID
+                }
+                if let campaignID = item.slCampaignID {
+                    obj["sl_campaign_id"] = campaignID
+                }
+                if let campaignOwner = item.slCampaignOwner {
+                    obj["sl_campaign_owner"] = campaignOwner
+                }
+                return obj
+            }
+            dict["items"] = itemsArray
+        } else if let loadedCustomerIDs = self.customerIDs {
+            let itemsArray = loadedCustomerIDs.map { ["item_id": $0] }
+            dict["items"] = itemsArray
+        }
         if (self.analyticsTags != nil) {
             dict["analytics_tags"] = self.analyticsTags
         }

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -539,6 +539,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         - podID: The pod ID
         - numResultsViewed: The count of results that is visible to the user
         - customerIDs: The items that were loaded
+        - items: The items that were loaded (preferred over customerIDs as it supports variation IDs)
         - resultPage: The current page that recommendation result is on
         - resultCount: The total number of recommendation results
         - sectionName: The name of the autocomplete section the term came from
@@ -549,13 +550,12 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
      ### Usage Example: ###
      ```
-     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
+     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, items: [CIOItem(customerID: "1234567-AB", variationID: "1234567-AB-47398")], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
      ```
      */
-    public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+    public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, items: [CIOItem]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIDs: seedItemIDs)
-
+        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIDs: seedItemIDs, items: items)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -538,8 +538,8 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      - Parameters:
         - podID: The pod ID
         - numResultsViewed: The count of results that is visible to the user
-        - customerIDs: The list of item id's returned in the browse (**Deprecated**. Use `items` (v4.2.0) instead.)
-        - items: The list of items returned in the search (Preferred over customerIDs)
+        - customerIDs: The list of item id's returned in the recommendation pod (**Deprecated**. Use `items` (v4.2.0) instead.)
+        - items: The list of items returned in the recommendation pod (Preferred over customerIDs)
         - resultPage: The current page that recommendation result is on
         - resultCount: The total number of recommendation results
         - sectionName: The name of the autocomplete section the term came from

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -552,9 +552,9 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      ```
      // Uses items parameter (preferred)
      constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, items: [CIOItem(customerID: "1234567-AB", variationID: "1234567-AB-47398"), CIOItem(customerID: "1234567-CD", variationID: "1234567-CD-8910")], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
-    
+     
      // Uses customerIDs parameter (deprecated)
-    constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234567-AC"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
+     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234567-AC"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
      ```
      */
     public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, items: [CIOItem]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -436,10 +436,10 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      
      ### Usage Example: ###
      ```
-     // Uses Items parameters (preferred)
+     // Uses items parameter (preferred)
      constructorIO.trackSearchResultsLoaded(searchTerm: "tooth", resultCount: 789, items: [CIOItem(id: "1234567-AB", name: "Toothpicks")])
 
-     // Uses CustomerIDs parameters (deprecated)
+     // Uses customerIDs parameter (deprecated)
      constructorIO.trackSearchResultsLoaded(searchTerm: "tooth", resultCount: 789, customerIDs: ["1234567-AB", "1234765-CD", "1234576-DE"])
      ```
      */
@@ -538,8 +538,8 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      - Parameters:
         - podID: The pod ID
         - numResultsViewed: The count of results that is visible to the user
-        - customerIDs: The items that were loaded
-        - items: The items that were loaded (preferred over customerIDs as it supports variation IDs)
+        - customerIDs: The list of item id's returned in the browse (**Deprecated**. Use `items` (v4.2.0) instead.)
+        - items: The list of items returned in the search (Preferred over customerIDs)
         - resultPage: The current page that recommendation result is on
         - resultCount: The total number of recommendation results
         - sectionName: The name of the autocomplete section the term came from

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -550,7 +550,11 @@ public class ConstructorIO: CIOSessionManagerDelegate {
 
      ### Usage Example: ###
      ```
-     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, items: [CIOItem(customerID: "1234567-AB", variationID: "1234567-AB-47398")], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
+     // Uses items parameter (preferred)
+     constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, items: [CIOItem(customerID: "1234567-AB", variationID: "1234567-AB-47398"), CIOItem(customerID: "1234567-CD", variationID: "1234567-CD-8910")], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
+    
+     // Uses customerIDs parameter (deprecated)
+    constructorIO.trackRecommendationResultsView(podID: "pdp_best_sellers", numResultsViewed: 5, customerIDs: ["1234567-AB", "1234567-AC"], resultPage: 1, resultCount: 10, resultID: "179b8a0e-3799-4a31-be87-127b06871de2", seedItemIDs: ["seed-item-123"])
      ```
      */
     public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, items: [CIOItem]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -56,7 +56,7 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(analyticsTagsPayload, analyticsTags)
     }
     
-    func testTrackRecommendationResultClickBuilder_WithItemsParam() {
+    func testTrackRecommendationResultClickBuilder_WithCustomerIDsParam() {
         let customerIDs = ["custID1", "custID2", "custID3"]
         let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: resultID)
         builder.build(trackData: recommendationViewData)
@@ -87,6 +87,18 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(loadedItems[1]["item_id"] as? String, items[1].customerID)
         XCTAssertEqual(loadedItems[1]["variation_id"] as? String, items[1].variationID)
     }
+    
+    func testTrackRecommendationResultsViewBuilder_WithItemsParam_NoVariationID() {
+        let items = [CIOItem(customerID: "custID1")]
+        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: resultID, items: items)
+        builder.build(trackData: data)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedItems = payload?["items"] as? [[String: Any]] ?? []
+
+        XCTAssertEqual(loadedItems[0]["item_id"] as? String, "custID1")
+        XCTAssertNil(loadedItems[0]["variation_id"], "variation_id should not be present when nil")
+    }
 
     func testTrackRecommendationResultsViewBuilder_WithSponsoredListingsParams() {
         let slCampaignID = "cmp456"
@@ -100,6 +112,7 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(loadedItems.count, 1)
+        XCTAssertEqual(loadedItems[0]["item_id"] as? String, "custID1")
         XCTAssertEqual(loadedItems[0]["sl_campaign_id"] as? String, slCampaignID)
         XCTAssertEqual(loadedItems[0]["sl_campaign_owner"] as? String, slCampaignOwner)
     }

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -69,6 +69,56 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(loadedItems[0]["item_id"], customerIDs[0])
     }
 
+    func testTrackRecommendationResultsViewBuilder_WithItemsParam() {
+        let items = [
+            CIOItem(customerID: "custID1", variationID: "var1"),
+            CIOItem(customerID: "custID2", variationID: "var2")
+        ]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: resultID, items: items)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedItems = payload?["items"] as? [[String: Any]] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedItems.count, 2)
+        XCTAssertEqual(loadedItems[0]["item_id"] as? String, items[0].customerID)
+        XCTAssertEqual(loadedItems[0]["variation_id"] as? String, items[0].variationID)
+        XCTAssertEqual(loadedItems[1]["item_id"] as? String, items[1].customerID)
+        XCTAssertEqual(loadedItems[1]["variation_id"] as? String, items[1].variationID)
+    }
+
+    func testTrackRecommendationResultsViewBuilder_WithSponsoredListingsParams() {
+        let slCampaignID = "cmp456"
+        let slCampaignOwner = "owner789"
+        let items = [CIOItem(customerID: "custID1", variationID: nil, quantity: nil, slCampaignID: slCampaignID, slCampaignOwner: slCampaignOwner)]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, items: items)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedItems = payload?["items"] as? [[String: Any]] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedItems.count, 1)
+        XCTAssertEqual(loadedItems[0]["sl_campaign_id"] as? String, slCampaignID)
+        XCTAssertEqual(loadedItems[0]["sl_campaign_owner"] as? String, slCampaignOwner)
+    }
+
+    func testTrackRecommendationResultsViewBuilder_WithItemsParamPreferredOverCustomerIDs() {
+        let customerIDs = ["custID1", "custID2", "custID3"]
+        let items = [CIOItem(customerID: "itemID1", variationID: "var1")]
+        let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, customerIDs: customerIDs, items: items)
+        builder.build(trackData: recommendationViewData)
+        let request = builder.getRequest()
+        let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
+        let loadedItems = payload?["items"] as? [[String: Any]] ?? []
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(loadedItems.count, 1)
+        XCTAssertEqual(loadedItems[0]["item_id"] as? String, items[0].customerID)
+        XCTAssertEqual(loadedItems[0]["variation_id"] as? String, items[0].variationID)
+    }
+
     func testTrackRecommendationResultsViewBuilder_WithSingleSeedItemID() {
         let seedItemIDs = ["seed-item-123"]
         let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, seedItemIDs: seedItemIDs)

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -37,7 +37,7 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(payload?["url"] as? String, "Not Available")
     }
 
-    func testTrackRecommendationResultClickBuilder_WithOptionalParams() {
+    func testTrackRecommendationResultsViewBuilder_WithOptionalParams() {
         let analyticsTags = ["test": "testing", "version": "123"]
         let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: resultID, analyticsTags: analyticsTags)
         builder.build(trackData: recommendationViewData)
@@ -56,7 +56,7 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         XCTAssertEqual(analyticsTagsPayload, analyticsTags)
     }
     
-    func testTrackRecommendationResultClickBuilder_WithCustomerIDsParam() {
+    func testTrackRecommendationResultsViewBuilder_WithCustomerIDsParam() {
         let customerIDs = ["custID1", "custID2", "custID3"]
         let recommendationViewData = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: sectionName, resultID: resultID)
         builder.build(trackData: recommendationViewData)

--- a/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackRecommendationViewRequestBuilder.swift
@@ -96,6 +96,7 @@ class TrackRecommendationResultsViewRequestBuilder: XCTestCase {
         let payload = try? JSONSerialization.jsonObject(with: request.httpBody!, options: []) as? [String: Any]
         let loadedItems = payload?["items"] as? [[String: Any]] ?? []
 
+        XCTAssertEqual(loadedItems.count, 1)
         XCTAssertEqual(loadedItems[0]["item_id"] as? String, "custID1")
         XCTAssertNil(loadedItems[0]["variation_id"], "variation_id should not be present when nil")
     }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackRecommendationResultsViewTests.swift
@@ -111,6 +111,20 @@ class ConstructorIOTrackRecommendationResultsViewTests: XCTestCase {
         self.wait(for: expectation)
     }
 
+    func testTrackRecommendationResultsView_WithItems() {
+        let podID = "item_page_1"
+        let items = [
+            CIOItem(customerID: "custID1", variationID: "var1"),
+            CIOItem(customerID: "custID2", variationID: "var2")
+        ]
+
+        let builder = CIOBuilder(expectation: "Calling trackRecommendationResultsView should send a valid request with items.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/v2/behavioral_action/recommendation_result_view?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+
+        self.constructor.trackRecommendationResultsView(podID: podID, items: items)
+        self.wait(for: builder.expectation)
+    }
+
     func testTrackRecommendationResultsView_WithSeedItemIDs() {
         let podID = "item_page_1"
         let seedItemIDs = ["seed-item-123", "seed-item-456"]


### PR DESCRIPTION
## Summary

Adds an `items: [CIOItem]?` param to `trackRecommendationResultsView` so callers
can pass `variationID`s. Mirrors `trackBrowseResultsLoaded`; `items` is preferred over
`customerIDs` when both are set. Backwards-compatible.

## Why one method, not two overloads

A separate `items:` overload would be ambiguous — with defaults on every param,
calls omitting both `customerIDs` and `items` (e.g.
`trackRecommendationResultsView(podID:)`) fail to compile. A single method
matches `trackBrowseResultsLoaded` and stays backwards-compatible.
