### PR TITLE
[CDX-457] Add support for `totalNumResultsPerSection` in autocomplete response parsing

### DIFF
--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -181,6 +181,7 @@ struct Constants {
     struct Response {
         static let singleSectionResultField = "suggestions"
         static let multiSectionResultField = "sections"
+        static let totalNumResultsPerSectionField = "total_num_results_per_section"
     }
 
     struct Result {

--- a/AutocompleteClient/FW/API/Parser/Autocomplete/CIOAutocompleteResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Autocomplete/CIOAutocompleteResponseParser.swift
@@ -40,7 +40,9 @@ public struct CIOAutocompleteResponseParser: AbstractAutocompleteResponseParser 
         var metadata = json
         metadata[Constants.Response.singleSectionResultField] = nil
 
-        return CIOAutocompleteResponse(sections: [Constants.Response.singleSectionResultField: results], json: json, request: request)
+        let totalNumResultsPerSection = json["total_num_results_per_section"] as? [String: Int] ?? [:]
+
+        return CIOAutocompleteResponse(sections: [Constants.Response.singleSectionResultField: results], json: json, request: request, totalNumResultsPerSection: totalNumResultsPerSection)
     }
 
     private func parse(multiSectionJson json: JSONObject) throws -> CIOAutocompleteResponse {
@@ -59,7 +61,10 @@ public struct CIOAutocompleteResponseParser: AbstractAutocompleteResponseParser 
 
         var metadata = json
         metadata[Constants.Response.multiSectionResultField] = nil
-        return CIOAutocompleteResponse(sections: results, json: json, request: request)
+
+        let totalNumResultsPerSection = json["total_num_results_per_section"] as? [String: Int] ?? [:]
+
+        return CIOAutocompleteResponse(sections: results, json: json, request: request, totalNumResultsPerSection: totalNumResultsPerSection)
     }
 
     fileprivate func jsonToAutocompleteItems(jsonObjects: [JSONObject]) -> [CIOAutocompleteResult] {

--- a/AutocompleteClient/FW/API/Parser/Autocomplete/CIOAutocompleteResponseParser.swift
+++ b/AutocompleteClient/FW/API/Parser/Autocomplete/CIOAutocompleteResponseParser.swift
@@ -40,7 +40,7 @@ public struct CIOAutocompleteResponseParser: AbstractAutocompleteResponseParser 
         var metadata = json
         metadata[Constants.Response.singleSectionResultField] = nil
 
-        let totalNumResultsPerSection = json["total_num_results_per_section"] as? [String: Int] ?? [:]
+        let totalNumResultsPerSection = json[Constants.Response.totalNumResultsPerSectionField] as? [String: Int] ?? [:]
 
         return CIOAutocompleteResponse(sections: [Constants.Response.singleSectionResultField: results], json: json, request: request, totalNumResultsPerSection: totalNumResultsPerSection)
     }
@@ -62,7 +62,7 @@ public struct CIOAutocompleteResponseParser: AbstractAutocompleteResponseParser 
         var metadata = json
         metadata[Constants.Response.multiSectionResultField] = nil
 
-        let totalNumResultsPerSection = json["total_num_results_per_section"] as? [String: Int] ?? [:]
+        let totalNumResultsPerSection = json[Constants.Response.totalNumResultsPerSectionField] as? [String: Int] ?? [:]
 
         return CIOAutocompleteResponse(sections: results, json: json, request: request, totalNumResultsPerSection: totalNumResultsPerSection)
     }

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOAutocompleteResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOAutocompleteResponse.swift
@@ -30,7 +30,8 @@ public struct CIOAutocompleteResponse {
     public var request: JSONObject
 
     /**
-     Total number of results per section
+     Total number of results available per section, keyed by section name.
+     Will be empty if the server did not include `total_num_results_per_section` in the response.
      */
     public let totalNumResultsPerSection: [String: Int]
 

--- a/AutocompleteClient/FW/Logic/Result/Responses/CIOAutocompleteResponse.swift
+++ b/AutocompleteClient/FW/Logic/Result/Responses/CIOAutocompleteResponse.swift
@@ -23,15 +23,21 @@ public struct CIOAutocompleteResponse {
      Additional information about the request and result ID
      */
     public let json: JSONObject
-    
+
     /**
      Request object used to retrieve the Autocomplete Response
      */
     public var request: JSONObject
 
-    public init(sections: [String: [CIOAutocompleteResult]], json: JSONObject, request: JSONObject = [:]) {
+    /**
+     Total number of results per section
+     */
+    public let totalNumResultsPerSection: [String: Int]
+
+    public init(sections: [String: [CIOAutocompleteResult]], json: JSONObject, request: JSONObject = [:], totalNumResultsPerSection: [String: Int] = [:]) {
         self.sections = sections
         self.json = json
         self.request = request
+        self.totalNumResultsPerSection = totalNumResultsPerSection
     }
 }

--- a/AutocompleteClientTests/FW/API/Parser/CIOAutocompleteResponseParserTests.swift
+++ b/AutocompleteClientTests/FW/API/Parser/CIOAutocompleteResponseParserTests.swift
@@ -156,4 +156,38 @@ class CIOAutocompleteResponseParserTests: XCTestCase {
             XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
         }
     }
+
+    func testParsingMultipleSectionJSONString_HasCorrectTotalNumResultsPerSection() {
+        let data = TestResource.load(name: TestResource.Response.multipleSectionsJSONFilename)
+        do {
+            let response = try responseParser.parse(autocompleteResponseData: data)
+            XCTAssertEqual(response.totalNumResultsPerSection["Products"], 156)
+            XCTAssertEqual(response.totalNumResultsPerSection["Search Suggestions"], 23)
+            XCTAssertEqual(response.totalNumResultsPerSection.count, 2)
+        } catch {
+            XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
+        }
+    }
+
+    func testParsingSingleSectionJSONString_HasCorrectTotalNumResultsPerSection() {
+        let data = TestResource.load(name: TestResource.Response.singleSectionJSONFilename)
+        do {
+            let response = try responseParser.parse(autocompleteResponseData: data)
+            XCTAssertEqual(response.totalNumResultsPerSection["Search Suggestions"], 15)
+            XCTAssertEqual(response.totalNumResultsPerSection.count, 1)
+        } catch {
+            XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
+        }
+    }
+
+    func testParsingJSONWithoutTotalNumResultsPerSection_ReturnsEmptyDictionary() {
+        let data = TestResource.load(name: TestResource.Response.multipleGroupsJSONFilename)
+        do {
+            responseParser.maxGroups = 0
+            let response = try responseParser.parse(autocompleteResponseData: data)
+            XCTAssertTrue(response.totalNumResultsPerSection.isEmpty, "totalNumResultsPerSection should be empty when field is not present in JSON")
+        } catch {
+            XCTFail("Parser should never throw an exception when a valid JSON string is passed.")
+        }
+    }
 }

--- a/AutocompleteClientTests/FW/API/Parser/CIOAutocompleteResponseParserTests.swift
+++ b/AutocompleteClientTests/FW/API/Parser/CIOAutocompleteResponseParserTests.swift
@@ -183,7 +183,6 @@ class CIOAutocompleteResponseParserTests: XCTestCase {
     func testParsingJSONWithoutTotalNumResultsPerSection_ReturnsEmptyDictionary() {
         let data = TestResource.load(name: TestResource.Response.multipleGroupsJSONFilename)
         do {
-            responseParser.maxGroups = 0
             let response = try responseParser.parse(autocompleteResponseData: data)
             XCTAssertTrue(response.totalNumResultsPerSection.isEmpty, "totalNumResultsPerSection should be empty when field is not present in JSON")
         } catch {

--- a/AutocompleteClientTests/Resources/response_json_multiple_sections.json
+++ b/AutocompleteClientTests/Resources/response_json_multiple_sections.json
@@ -320,6 +320,10 @@
       }
     ]
   },
+  "total_num_results_per_section": {
+      "Products": 156,
+      "Search Suggestions": 23
+  },
   "request": {
       "num_results_per_page": 20,
       "sort_by": "relevance",

--- a/AutocompleteClientTests/Resources/response_json_single_section.json
+++ b/AutocompleteClientTests/Resources/response_json_single_section.json
@@ -208,6 +208,9 @@
       }
     ]
   },
+  "total_num_results_per_section": {
+      "Search Suggestions": 15
+  },
   "request": {
       "num_results_per_page": 20,
       "sort_by": "relevance",


### PR DESCRIPTION
* Extend `CIOAutocompleteResponse` to include `totalNumResultsPerSection`.
* Update parser logic to extract `total_num_results_per_section` from JSON.
* Add unit tests to validate parsing of `totalNumResultsPerSection`.