### PR TITLE
[CDX-486] Add support for analyticsTags in trackSearchSubmit

### DIFF
--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -217,7 +217,7 @@ struct Constants {
         static let orderID = "order_id"
         static let defaultConversionType = "add_to_cart"
         static let conversionType = "type"
-        static let analyticsTagsKey = { (key: String) -> String in "analytics_tags[\(key)]" }
+        static let analyticTagKey = { (key: String) -> String in "analytics_tags[\(key)]" }
     }
 
     struct TrackSessionStart {

--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -217,6 +217,7 @@ struct Constants {
         static let orderID = "order_id"
         static let defaultConversionType = "add_to_cart"
         static let conversionType = "type"
+        static let analyticsTagsKey = { (key: String) -> String in "analytics_tags[\(key)]" }
     }
 
     struct TrackSessionStart {

--- a/AutocompleteClient/Constants/Constants.swift
+++ b/AutocompleteClient/Constants/Constants.swift
@@ -217,7 +217,7 @@ struct Constants {
         static let orderID = "order_id"
         static let defaultConversionType = "add_to_cart"
         static let conversionType = "type"
-        static let analyticTagKey = { (key: String) -> String in "analytics_tags[\(key)]" }
+        static let analyticsTagsKey = { (key: String) -> String in "analytics_tags[\(key)]" }
     }
 
     struct TrackSessionStart {

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -26,6 +26,13 @@ extension RequestBuilder {
         queryItems.add(URLQueryItem(name: Constants.Track.groupID, value: groupID))
     }
 
+    func set(analyticsTags: [String: String]?) {
+        guard let analyticsTags = analyticsTags else { return }
+        analyticsTags.forEach {
+            queryItems.add(URLQueryItem(name: Constants.Track.analyticsTagsKey($0.key), value: $0.value))
+        }
+    }
+
     func set(searchTerm: String) {
         queryItems.add(URLQueryItem(name: Constants.Track.searchTerm, value: searchTerm))
     }

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -29,7 +29,7 @@ extension RequestBuilder {
     func set(analyticsTags: [String: String]?) {
         guard let analyticsTags = analyticsTags else { return }
         analyticsTags.forEach {
-            queryItems.add(URLQueryItem(name: Constants.Track.analyticsTagsKey($0.key), value: $0.value))
+            queryItems.add(URLQueryItem(name: Constants.Track.analyticTagKey($0.key), value: $0.value))
         }
     }
 

--- a/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
+++ b/AutocompleteClient/FW/Logic/Request/Builder/RequestBuilder+QueryItems.swift
@@ -29,7 +29,7 @@ extension RequestBuilder {
     func set(analyticsTags: [String: String]?) {
         guard let analyticsTags = analyticsTags else { return }
         analyticsTags.forEach {
-            queryItems.add(URLQueryItem(name: Constants.Track.analyticTagKey($0.key), value: $0.value))
+            queryItems.add(URLQueryItem(name: Constants.Track.analyticsTagsKey($0.key), value: $0.value))
         }
     }
 

--- a/AutocompleteClient/FW/Logic/Request/CIOTrackSearchSubmitData.swift
+++ b/AutocompleteClient/FW/Logic/Request/CIOTrackSearchSubmitData.swift
@@ -16,15 +16,17 @@ struct CIOTrackSearchSubmitData: CIORequestData {
     let searchTerm: String
     let originalQuery: String
     let group: CIOGroup?
+    let analyticsTags: [String: String]?
 
     func url(with baseURL: String) -> String {
         return String(format: Constants.TrackSearchSubmit.format, baseURL, self.searchTerm.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!)
     }
 
-    init(searchTerm: String, originalQuery: String, group: CIOGroup? = nil) {
+    init(searchTerm: String, originalQuery: String, group: CIOGroup? = nil, analyticsTags: [String: String]? = nil) {
         self.searchTerm = searchTerm
         self.originalQuery = originalQuery
         self.group = group
+        self.analyticsTags = analyticsTags
     }
 
     func decorateRequest(requestBuilder: RequestBuilder) {
@@ -33,5 +35,6 @@ struct CIOTrackSearchSubmitData: CIORequestData {
             requestBuilder.set(groupName: group.displayName)
             requestBuilder.set(groupID: group.groupID)
         }
+        requestBuilder.set(analyticsTags: self.analyticsTags)
     }
 }

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -440,6 +440,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         - searchTerm: The term that the user searched for
         - originalQuery: The current text in the input field
         - group: The group to search within. Only required if searching within a group, i.e. "Pumpkin in Canned Goods"
+        - analyticsTags: Additional analytics tags to pass
         - completionHandler: The callback to execute on completion.
 
      ### Usage Example: ###
@@ -447,8 +448,8 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      constructorIO.trackSearchSubmit(searchTerm: "apple", originalQuery: "app")
      ```
      */
-    public func trackSearchSubmit(searchTerm: String, originalQuery: String, group: CIOGroup? = nil, completionHandler: TrackingCompletionHandler? = nil) {
-        let data = CIOTrackSearchSubmitData(searchTerm: searchTerm, originalQuery: originalQuery, group: group)
+    public func trackSearchSubmit(searchTerm: String, originalQuery: String, group: CIOGroup? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
+        let data = CIOTrackSearchSubmitData(searchTerm: searchTerm, originalQuery: originalQuery, group: group, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -1010,8 +1011,8 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         } else if (baseDictionary != nil && !baseDictionary!.isEmpty) {
             return baseDictionary!.merging(newDictionary!) { (_, new) in new }
         }
-        
-        return nil
+
+        return newDictionary
     }
 
 

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -1006,13 +1006,13 @@ public class ConstructorIO: CIOSessionManagerDelegate {
     }
     
     private func mergeDictionary(baseDictionary: [String: String]?, newDictionary: [String: String]?) -> [String: String]? {
-        if (newDictionary == nil || newDictionary!.isEmpty) {
-            return baseDictionary
-        } else if (baseDictionary != nil && !baseDictionary!.isEmpty) {
-            return baseDictionary!.merging(newDictionary!) { (_, new) in new }
+         guard let newDictionary = newDictionary, !newDictionary.isEmpty else {
+            return baseDictionary?.isEmpty == true ? nil : baseDictionary
         }
-
-        return newDictionary
+        guard let baseDictionary = baseDictionary, !baseDictionary.isEmpty else {
+            return newDictionary
+        }
+        return baseDictionary.merging(newDictionary) { (_, new) in new }
     }
 
 

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -1005,8 +1005,18 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         self.sessionID = sessionID
     }
     
+
+    /**
+     Merge two dictionaries, with values in `newDictionary` taking precedence over matching keys in `baseDictionary`
+
+     - Parameters:
+        - baseDictionary: The dictionary to merge into
+        - newDictionary: The dictionary whose values override the base dictionary's values
+
+     - Returns: The merged dictionary, or `nil` when both dictionaries are nil or empty.
+     */
     private func mergeDictionary(baseDictionary: [String: String]?, newDictionary: [String: String]?) -> [String: String]? {
-         guard let newDictionary = newDictionary, !newDictionary.isEmpty else {
+        guard let newDictionary = newDictionary, !newDictionary.isEmpty else {
             return baseDictionary?.isEmpty == true ? nil : baseDictionary
         }
         guard let baseDictionary = baseDictionary, !baseDictionary.isEmpty else {

--- a/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
+++ b/AutocompleteClient/FW/Logic/Worker/ConstructorIO.swift
@@ -449,7 +449,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      ```
      */
     public func trackSearchSubmit(searchTerm: String, originalQuery: String, group: CIOGroup? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
-        let data = CIOTrackSearchSubmitData(searchTerm: searchTerm, originalQuery: originalQuery, group: group, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackSearchSubmitData(searchTerm: searchTerm, originalQuery: originalQuery, group: group, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -476,7 +476,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      ```
      */
     public func trackSearchResultsLoaded(searchTerm: String, resultCount: Int, customerIDs: [String]? = nil, items: [CIOItem]? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
-        let data = CIOTrackSearchResultsLoadedData(searchTerm: searchTerm, resultCount: resultCount, resultID: resultID, url: "Not Available", customerIDs: customerIDs, items: items, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackSearchResultsLoadedData(searchTerm: searchTerm, resultCount: resultCount, resultID: resultID, url: "Not Available", customerIDs: customerIDs, items: items, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -531,7 +531,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      ```
      */
     public func trackBrowseResultsLoaded(filterName: String, filterValue: String, resultCount: Int, customerIDs: [String]? = nil, items: [CIOItem]? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
-        let data = CIOTrackBrowseResultsLoadedData(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, url: "Not Available", customerIDs: customerIDs, items: items, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackBrowseResultsLoadedData(filterName: filterName, filterValue: filterValue, resultCount: resultCount, resultID: resultID, url: "Not Available", customerIDs: customerIDs, items: items, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -559,7 +559,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackBrowseResultClick(customerID: String, variationID: String? = nil, filterName: String, filterValue: String, resultPositionOnPage: Int?, sectionName: String? = nil, resultID: String? = nil, slCampaignID: String? = nil, slCampaignOwner: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackBrowseResultClickData(filterName: filterName, filterValue: filterValue, customerID: customerID, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, variationID: variationID, slCampaignID: slCampaignID, slCampaignOwner: slCampaignOwner, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackBrowseResultClickData(filterName: filterName, filterValue: filterValue, customerID: customerID, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, variationID: variationID, slCampaignID: slCampaignID, slCampaignOwner: slCampaignOwner, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -591,7 +591,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackRecommendationResultsView(podID: String, numResultsViewed: Int? = nil, customerIDs: [String]? = nil, items: [CIOItem]? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIDs: seedItemIDs, items: items)
+        let data = CIOTrackRecommendationResultsViewData(podID: podID, numResultsViewed: numResultsViewed, customerIDs: customerIDs, resultPage: resultPage, resultCount: resultCount, sectionName: section, resultID: resultID, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags), seedItemIDs: seedItemIDs, items: items)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -621,7 +621,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackRecommendationResultClick(podID: String, strategyID: String? = nil, customerID: String, variationID: String? = nil, numResultsPerPage: Int? = nil, resultPage: Int? = nil, resultCount: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, resultID: String? = nil, analyticsTags: [String: String]? = nil, seedItemIDs: [String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackRecommendationResultClickData(podID: podID, strategyID: strategyID, customerID: customerID, variationID: variationID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags), seedItemIDs: seedItemIDs)
+        let data = CIOTrackRecommendationResultClickData(podID: podID, strategyID: strategyID, customerID: customerID, variationID: variationID, numResultsPerPage: numResultsPerPage, resultPage: resultPage, resultCount: resultCount, resultPositionOnPage: resultPositionOnPage, sectionName: section, resultID: resultID, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags), seedItemIDs: seedItemIDs)
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -651,7 +651,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
         let type = conversionType ?? Constants.Track.defaultConversionType
         let term = searchTerm == nil ? "TERM_UNKNOWN" : (searchTerm!.isEmpty) ? "TERM_UNKNOWN" : searchTerm
-        let data = CIOTrackConversionData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, revenue: revenue, conversionType: type, variationID: variationID, displayName: displayName, isCustomType: isCustomType, analyticsTags: analyticsTags)
+        let data = CIOTrackConversionData(searchTerm: term!, itemName: itemName, customerID: customerID, sectionName: section, revenue: revenue, conversionType: type, variationID: variationID, displayName: displayName, isCustomType: isCustomType, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -674,7 +674,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackPurchase(customerIDs: [String], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackPurchaseData(customerIDs: customerIDs, sectionName: section, revenue: revenue, orderID: orderID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackPurchaseData(customerIDs: customerIDs, sectionName: section, revenue: revenue, orderID: orderID, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -697,7 +697,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackPurchase(items: [CIOItem], sectionName: String? = nil, revenue: Double? = nil, orderID: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackPurchaseData(items: items, sectionName: section, revenue: revenue, orderID: orderID, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackPurchaseData(items: items, sectionName: section, revenue: revenue, orderID: orderID, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -720,7 +720,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackItemDetailLoad(customerID: String, itemName: String, variationID: String? = nil, sectionName: String? = nil, url: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackItemDetailLoadData(itemName: itemName, customerID: customerID, variationID: variationID, sectionName: section, url: url ?? "Not Available", analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackItemDetailLoadData(itemName: itemName, customerID: customerID, variationID: variationID, sectionName: section, url: url ?? "Not Available", analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -751,7 +751,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackQuizResultsLoaded(quizID: String, quizVersionID: String, quizSessionID: String, resultID: String? = nil, resultPage: Int? = nil, resultCount: Int? = nil, sectionName: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackQuizResultsLoadedData(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, resultID: resultID, resultPage: resultPage, resultCount: resultCount, sectionName: section, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackQuizResultsLoadedData(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, resultID: resultID, resultPage: resultPage, resultCount: resultCount, sectionName: section, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -782,7 +782,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackQuizResultClick(quizID: String, quizVersionID: String, quizSessionID: String, customerID: String, variationID: String? = nil, itemName: String? = nil, resultID: String? = nil, resultPage: Int? = nil, resultCount: Int? = nil, numResultsPerPage: Int? = nil, resultPositionOnPage: Int? = nil, sectionName: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackQuizResultClickData(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, variationID: variationID, itemName: itemName, resultID: resultID, resultPage: resultPage, resultCount: resultCount, numResultsPerPage: numResultsPerPage, resultPositionOnPage: resultPositionOnPage, sectionName: section, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackQuizResultClickData(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, variationID: variationID, itemName: itemName, resultID: resultID, resultPage: resultPage, resultCount: resultCount, numResultsPerPage: numResultsPerPage, resultPositionOnPage: resultPositionOnPage, sectionName: section, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -812,7 +812,7 @@ public class ConstructorIO: CIOSessionManagerDelegate {
      */
     public func trackQuizConversion(quizID: String, quizVersionID: String, quizSessionID: String, customerID: String, variationID: String? = nil, itemName: String? = nil, revenue: Double? = nil, conversionType: String? = nil, isCustomType: Bool? = nil, displayName: String? = nil, sectionName: String? = nil, analyticsTags: [String: String]? = nil, completionHandler: TrackingCompletionHandler? = nil) {
         let section = sectionName ?? self.config.defaultItemSectionName ?? Constants.Track.defaultItemSectionName
-        let data = CIOTrackQuizConversionData(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, variationID: variationID, itemName: itemName, revenue: revenue, conversionType: conversionType, isCustomType: isCustomType, displayName: displayName, sectionName: section, analyticsTags: mergeDictionary(baseDictionary: self.config.defaultAnalyticsTags, newDictionary: analyticsTags))
+        let data = CIOTrackQuizConversionData(quizID: quizID, quizVersionID: quizVersionID, quizSessionID: quizSessionID, customerID: customerID, variationID: variationID, itemName: itemName, revenue: revenue, conversionType: conversionType, isCustomType: isCustomType, displayName: displayName, sectionName: section, analyticsTags: mergeAnalyticsTags(defaultAnalyticsTags: self.config.defaultAnalyticsTags, newAnalyticsTags: analyticsTags))
         let request = self.buildRequest(data: data)
         executeTracking(request, completionHandler: completionHandler)
     }
@@ -1007,22 +1007,22 @@ public class ConstructorIO: CIOSessionManagerDelegate {
     
 
     /**
-     Merge two dictionaries, with values in `newDictionary` taking precedence over matching keys in `baseDictionary`
+     Merge default and per-request analytics tags, with values in `newAnalyticsTags` taking precedence over matching keys in `defaultAnalyticsTags`
 
      - Parameters:
-        - baseDictionary: The dictionary to merge into
-        - newDictionary: The dictionary whose values override the base dictionary's values
+        - defaultAnalyticsTags: The analytics tags to merge into
+        - newAnalyticsTags: The analytics tags whose values override the default analytics tags' values
 
-     - Returns: The merged dictionary, or `nil` when both dictionaries are nil or empty.
+     - Returns: The merged analytics tags, or `nil` when both are nil or empty.
      */
-    private func mergeDictionary(baseDictionary: [String: String]?, newDictionary: [String: String]?) -> [String: String]? {
-        guard let newDictionary = newDictionary, !newDictionary.isEmpty else {
-            return baseDictionary?.isEmpty == true ? nil : baseDictionary
+    private func mergeAnalyticsTags(defaultAnalyticsTags: [String: String]?, newAnalyticsTags: [String: String]?) -> [String: String]? {
+        guard let newAnalyticsTags = newAnalyticsTags, !newAnalyticsTags.isEmpty else {
+            return defaultAnalyticsTags?.isEmpty == true ? nil : defaultAnalyticsTags
         }
-        guard let baseDictionary = baseDictionary, !baseDictionary.isEmpty else {
-            return newDictionary
+        guard let defaultAnalyticsTags = defaultAnalyticsTags, !defaultAnalyticsTags.isEmpty else {
+            return newAnalyticsTags
         }
-        return baseDictionary.merging(newDictionary) { (_, new) in new }
+        return defaultAnalyticsTags.merging(newAnalyticsTags) { (_, new) in new }
     }
 
 

--- a/AutocompleteClientTests/FW/Logic/Request/TrackSearchSubmitRequestBuilder.swift
+++ b/AutocompleteClientTests/FW/Logic/Request/TrackSearchSubmitRequestBuilder.swift
@@ -70,4 +70,23 @@ class TrackSearchSubmitRequestBuilderTests: XCTestCase {
         XCTAssertFalse(url.contains("group%5Bgroup_name%5D"), "URL shouldn't contain a URL query item with group id if item outside a group")
         XCTAssertFalse(url.contains("group%5Bgroup_id%5D"), "URL shouldn't contain a URL query item with group name if item outside a group")
     }
+
+    func testTrackSearchSubmitBuilder_WithAnalyticsTags() {
+        let tracker = CIOTrackSearchSubmitData(searchTerm: searchTerm, originalQuery: originalQuery, analyticsTags: ["tag1": "value1", "tag2": "value2"])
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+
+        XCTAssertTrue(url.contains("analytics_tags%5Btag1%5D=value1"), "URL should contain a nested query item for each analytics tag")
+        XCTAssertTrue(url.contains("analytics_tags%5Btag2%5D=value2"), "URL should contain a nested query item for each analytics tag")
+    }
+
+    func testTrackSearchSubmitBuilder_WithoutAnalyticsTags() {
+        let tracker = CIOTrackSearchSubmitData(searchTerm: searchTerm, originalQuery: originalQuery, analyticsTags: nil)
+        builder.build(trackData: tracker)
+        let request = builder.getRequest()
+        let url = request.url!.absoluteString
+
+        XCTAssertFalse(url.contains("analytics_tags"), "URL shouldn't contain analytics tags query items when none are provided")
+    }
 }

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOIntegrationTests.swift
@@ -811,7 +811,7 @@ class ConstructorIOIntegrationTests: XCTestCase {
         self.constructor.search(forQuery: query, completionHandler: { response in
             let cioError = response.error as? CIOError
             XCTAssertNotNil(cioError)
-            XCTAssertEqual(cioError?.errorMessage, "num_results_per_page: ensure this value is less than or equal to 200")
+            XCTAssertEqual(cioError?.errorMessage, "num_results_per_page: Input should be less than or equal to 200")
             expectation.fulfill()
         })
         self.wait(for: expectation)

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackSearchSubmitTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackSearchSubmitTests.swift
@@ -33,6 +33,46 @@ class ConstructorIOTrackSearchSubmitTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testTrackSearchSubmit_WithDefaultAnalyticsTagsOnly() {
+        let searchTerm = "corn"
+        let searchOriginalQuery = "corn"
+        let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultAnalyticsTags: ["default_tag": "default_value"])
+        let constructor = TestConstants.testConstructor(config)
+        let builder = CIOBuilder(expectation: "Calling trackSearchSubmit with only defaultAnalyticsTags should send the default tags.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/search?_dt=\(kRegexTimestamp)&analytics_tags%5Bdefault_tag%5D=default_value&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&original_query=corn&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+        constructor.trackSearchSubmit(searchTerm: searchTerm, originalQuery: searchOriginalQuery)
+        self.wait(for: builder.expectation)
+    }
+
+    func testTrackSearchSubmit_WithAnalyticsTagsOnly() {
+        let searchTerm = "corn"
+        let searchOriginalQuery = "corn"
+        let builder = CIOBuilder(expectation: "Calling trackSearchSubmit with only analyticsTags should send the passed tags.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/search?_dt=\(kRegexTimestamp)&analytics_tags%5Btag1%5D=value1&analytics_tags%5Btag2%5D=value2&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&original_query=corn&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+        self.constructor.trackSearchSubmit(searchTerm: searchTerm, originalQuery: searchOriginalQuery, analyticsTags: ["tag1": "value1", "tag2": "value2"])
+        self.wait(for: builder.expectation)
+    }
+
+    func testTrackSearchSubmit_WithDefaultAndAnalyticsTagsMerged() {
+        let searchTerm = "corn"
+        let searchOriginalQuery = "corn"
+        let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultAnalyticsTags: ["default_tag": "default_value"])
+        let constructor = TestConstants.testConstructor(config)
+        let builder = CIOBuilder(expectation: "Calling trackSearchSubmit with both should merge defaultAnalyticsTags and analyticsTags.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/search?_dt=\(kRegexTimestamp)&analytics_tags%5Bdefault_tag%5D=default_value&analytics_tags%5Btag1%5D=value1&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&original_query=corn&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+        constructor.trackSearchSubmit(searchTerm: searchTerm, originalQuery: searchOriginalQuery, analyticsTags: ["tag1": "value1"])
+        self.wait(for: builder.expectation)
+    }
+
+    func testTrackSearchSubmit_WithNoAnalyticsTags() {
+        let searchTerm = "corn"
+        let searchOriginalQuery = "corn"
+        let builder = CIOBuilder(expectation: "Calling trackSearchSubmit with no analytics tags should not send any.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/search?_dt=\(kRegexTimestamp)&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&original_query=corn&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+        self.constructor.trackSearchSubmit(searchTerm: searchTerm, originalQuery: searchOriginalQuery)
+        self.wait(for: builder.expectation)
+    }
+
     func testTrackSearchSubmit_With400() {
         let expectation = self.expectation(description: "Calling trackSearchSubmit with 400 should return badRequest CIOError.")
         let searchTerm = "corn"

--- a/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackSearchSubmitTests.swift
+++ b/AutocompleteClientTests/FW/Logic/Worker/ConstructorIOTrackSearchSubmitTests.swift
@@ -64,6 +64,17 @@ class ConstructorIOTrackSearchSubmitTests: XCTestCase {
         self.wait(for: builder.expectation)
     }
 
+    func testTrackSearchSubmit_WithAnalyticsTagsOverridingDefault() {
+        let searchTerm = "corn"
+        let searchOriginalQuery = "corn"
+        let config = ConstructorIOConfig(apiKey: TestConstants.testApiKey, defaultAnalyticsTags: ["default_tag": "default_value"])
+        let constructor = TestConstants.testConstructor(config)
+        let builder = CIOBuilder(expectation: "Calling trackSearchSubmit with analyticsTags overriding a defaultAnalyticsTags key should send only the per-request value.", builder: http(200))
+        stub(regex("https://ac.cnstrc.com/autocomplete/corn/search?_dt=\(kRegexTimestamp)&analytics_tags%5Bdefault_tag%5D=overridden_value&c=\(kRegexVersion)&i=\(kRegexClientID)&key=\(kRegexAutocompleteKey)&original_query=corn&s=\(kRegexSession)&\(TestConstants.defaultSegments)"), builder.create())
+        constructor.trackSearchSubmit(searchTerm: searchTerm, originalQuery: searchOriginalQuery, analyticsTags: ["default_tag": "overridden_value"])
+        self.wait(for: builder.expectation)
+    }
+
     func testTrackSearchSubmit_WithNoAnalyticsTags() {
         let searchTerm = "corn"
         let searchOriginalQuery = "corn"


### PR DESCRIPTION
## Summary
Adds an optional `analyticsTags: [String: String]?` parameter to the public `trackSearchSubmit` method, merged with `config.defaultAnalyticsTags`.

## Key Thing to Note (v1 endpoint)
* Unlike `trackSearchResultsLoaded` (and other v2 endpoints) which POST `analytics_tags` as a JSON object in the request body, `trackSearchSubmit` still hits the v1 `GET /autocomplete/{term}/search` endpoint.
* So the tags are encoded as **nested URL query items** (one per tag)
Example:
```
analytics_tags[tag1]=value1&analytics_tags[tag2]=value2
```
* The public interface for the `analyticsTags` param follows the convention of `[String: String]?`, which is consistent with every other track method. The difference between v1 and v2 is handled internally.

## Changes
1. `Constants`: added `Track.analyticsTagsKey` as a key builder
2.`RequestBuilder+QueryItems`: added `set(analyticsTags:)` function that expands the received param object into one nested query item per tag.
3. `CIOTrackSearchSubmitData`: added `analyticsTags` to data struct, used in `init` and `decorateRequest`.
4. `ConstructorIO`: added the `analyticsTags` param to `trackSearchSubmit` function + doc comment, merges with `defaultAnalyticsTags` via `mergeDictionary`.
5. Tests added in `TrackSearchSubmitRequestBuilder` and `ConstructorIOTrackSearchSubmit`
6. Refactor `mergeDictionary` helper method to correctly merge the dictionary and not unintentionally dropping `defaultAnalyticsTags` when only `analyticsTags` was present.
7. Renamed `mergeDictionary` to `mergeAnalyticsKeys` to reflect the function more accurately. Also to align with Android's naming convention.
8. Update `testSearch_WithInvalidParameterValue` in `ConstructorIOIntegrationTests`, seems like there is an update to the error message: "num_results_per_page: Input should be less than or equal to 200"
9. Update `trackConversion` to use `mergeDictionary`